### PR TITLE
更新README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Claude Code 编排 Codex + Gemini 的多模型协作开发系统。前端任务�
 npx ccg-workflow
 ```
 
-**要求**：Claude Code CLI、Node.js 18+
+**要求**：Claude Code CLI、Node.js 20+
+
+> **重要**：本项目依赖 `ora@9.x` 和 `string-width@8.x`，这些包要求 Node.js >= 20。使用 Node.js 18 会导致 `SyntaxError: Invalid regular expression flags` 错误。请确保升级到 Node.js 20 或更高版本。
 
 **可选**：Codex CLI（后端）、Gemini CLI（前端）
 


### PR DESCRIPTION
我遇到的情况：
C:\Users\19737>npx ccg-workflow
Need to install the following packages:
ccg-workflow@1.7.47
Ok to proceed? (y) y

npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'ora@9.1.0',
npm warn EBADENGINE   required: { node: '>=20' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'string-width@8.1.0',
npm warn EBADENGINE   required: { node: '>=20' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
file:///E:/nodejs/node_cache/_npx/2f75123001b35989/node_modules/string-width/index.js:16
const zeroWidthClusterRegex = /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/v;
                              ^

SyntaxError: Invalid regular expression flags
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:152:18)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:299:14)

Node.js v18.20.8

原README.md内容 18+ 版本不对

项目依赖 ora@^9.0.0，该包要求 Node.js >= 20
依赖 string-width@8.1.0 也要求 Node.js >= 20
项目中包含正则表达式，而Node.js 18 不支持正则表达式的 v 标志