### PR TITLE
feat: 为 codeagent-wrapper 添加 Gemini 模型参数支持

### DIFF
--- a/codeagent-wrapper/backend.go
+++ b/codeagent-wrapper/backend.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Backend defines the contract for invoking different AI CLI backends.
@@ -120,7 +121,16 @@ func buildGeminiArgs(cfg *Config, targetArg string) []string {
 	if cfg == nil {
 		return nil
 	}
-	args := []string{"--output-format", "stream-json", "-y"}
+
+	args := []string{}
+
+	// Add model parameter first (if specified)
+	if model := strings.TrimSpace(cfg.GeminiModel); model != "" {
+		args = append(args, "-m", model)
+	}
+
+	// Existing args
+	args = append(args, "-o", "stream-json", "-y")
 
 	if cfg.Mode == "resume" {
 		if cfg.SessionID != "" {


### PR DESCRIPTION
新增功能：
- 添加 --gemini-model 参数，支持指定 Gemini 模型（如 gemini-2.5-flash）
- 支持 GEMINI_MODEL 环境变量配置，CLI 参数优先级高于环境变量
- 模型参数自动插入到 gemini CLI 调用的正确位置（-m 参数在其他参数之前）
- 添加详细的日志记录和警告提示
- 更新帮助文档，说明参数用法和示例

技术实现：
- Config 结构体新增 GeminiModel 字段
- parseArgs() 函数支持 --gemini-model 和 --gemini-model=<value> 两种语法
- buildGeminiArgs() 函数在构建参数时优先插入模型参数
- 添加跨后端和并行模式的参数验证警告

版本更新：v5.7.1 → v5.7.2