### PR TITLE
feat: add MiniMax as fourth AI backend provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ A multi-model collaboration development system where Claude Code orchestrates Co
 ```
 Claude Code (Orchestrator)
        │
-   ┌───┴───┐
-   ↓       ↓
-Codex   Gemini
-(Backend) (Frontend)
-   │       │
-   └───┬───┘
+   ┌───┼───────┐
+   ↓   ↓       ↓
+Codex Gemini  MiniMax
+(Backend) (Frontend) (Alternative)
+   │   │       │
+   └───┼───────┘
        ↓
   Unified Patch
 ```
@@ -48,6 +48,7 @@ External models have no write access — they only return patches, which Claude 
 | **jq** | Yes | Used for auto-authorization hook ([install](#install-jq)) |
 | **Codex CLI** | No | Enables backend routing |
 | **Gemini CLI** | No | Enables frontend routing |
+| **MiniMax API Key** | No | Enables MiniMax backend (`MINIMAX_API_KEY` env var) |
 
 ### Installation
 
@@ -218,6 +219,8 @@ Configure in `~/.claude/settings.json` under `"env"`:
 | `CODEX_TIMEOUT` | Wrapper execution timeout (sec) | `7200` | Increase for very long tasks |
 | `BASH_DEFAULT_TIMEOUT_MS` | Claude Code Bash timeout (ms) | `120000` | Increase if commands time out |
 | `BASH_MAX_TIMEOUT_MS` | Claude Code Bash max timeout (ms) | `600000` | Increase for long builds |
+| `MINIMAX_API_KEY` | MiniMax API key for MiniMax backend | — | Required when using `--backend minimax` |
+| `MINIMAX_MODEL` | MiniMax model name | `MiniMax-M2.5` | Use `MiniMax-M2.5-highspeed` for faster responses |
 
 <details>
 <summary>Example settings.json</summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,12 +25,12 @@ Claude Code 编排 Codex + Gemini 的多模型协作开发系统。前端任务�
 ```
 Claude Code (编排)
        │
-   ┌───┴───┐
-   ↓       ↓
-Codex   Gemini
-(后端)   (前端)
-   │       │
-   └───┬───┘
+   ┌───┼───────┐
+   ↓   ↓       ↓
+Codex Gemini  MiniMax
+(后端) (前端) (备选)
+   │   │       │
+   └───┼───────┘
        ↓
   Unified Patch
 ```
@@ -48,6 +48,7 @@ Codex   Gemini
 | **jq** | 是 | 用于自动授权 Hook（[安装方法](#安装-jq)） |
 | **Codex CLI** | 否 | 启用后端路由 |
 | **Gemini CLI** | 否 | 启用前端路由 |
+| **MiniMax API Key** | 否 | 启用 MiniMax 后端（`MINIMAX_API_KEY` 环境变量） |
 
 ### 安装
 
@@ -218,6 +219,8 @@ npx ccg-workflow menu  # 选择「安装 Claude Code」
 | `CODEX_TIMEOUT` | wrapper 执行超时（秒） | `7200` | 超长任务时增大 |
 | `BASH_DEFAULT_TIMEOUT_MS` | Claude Code Bash 超时（毫秒） | `120000` | 命令超时时增大 |
 | `BASH_MAX_TIMEOUT_MS` | Claude Code Bash 最大超时（毫秒） | `600000` | 长时间构建时增大 |
+| `MINIMAX_API_KEY` | MiniMax API 密钥 | — | 使用 `--backend minimax` 时必需 |
+| `MINIMAX_MODEL` | MiniMax 模型名称 | `MiniMax-M2.5` | 可切换为 `MiniMax-M2.5-highspeed` 获得更快响应 |
 
 <details>
 <summary>settings.json 示例</summary>

--- a/codeagent-wrapper/backend.go
+++ b/codeagent-wrapper/backend.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const defaultMinimaxModel = "MiniMax-M2.5"
+
 // Backend defines the contract for invoking different AI CLI backends.
 // Each backend is responsible for supplying the executable command and
 // building the argument list based on the wrapper config.
@@ -145,6 +147,41 @@ func buildGeminiArgs(cfg *Config, targetArg string) []string {
 	if cfg.Mode != "resume" && cfg.WorkDir != "" {
 		args = append(args, "--include-directories", cfg.WorkDir)
 	}
+
+	args = append(args, "-p", targetArg)
+
+	return args
+}
+
+// MinimaxBackend invokes the codeagent-wrapper itself in --minimax-api mode,
+// which calls the MiniMax API (OpenAI-compatible) directly and outputs
+// Gemini-compatible stream-json to stdout.
+type MinimaxBackend struct{}
+
+func (MinimaxBackend) Name() string { return "minimax" }
+func (MinimaxBackend) Command() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "codeagent-wrapper"
+	}
+	return exe
+}
+func (MinimaxBackend) BuildArgs(cfg *Config, targetArg string) []string {
+	return buildMinimaxArgs(cfg, targetArg)
+}
+
+func buildMinimaxArgs(cfg *Config, targetArg string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	args := []string{"--minimax-api"}
+
+	model := strings.TrimSpace(cfg.MinimaxModel)
+	if model == "" {
+		model = defaultMinimaxModel
+	}
+	args = append(args, "-m", model)
 
 	args = append(args, "-p", targetArg)
 

--- a/codeagent-wrapper/backend_test.go
+++ b/codeagent-wrapper/backend_test.go
@@ -138,21 +138,30 @@ func TestClaudeBuildArgs_GeminiAndCodexModes(t *testing.T) {
 
 func TestClaudeBuildArgs_BackendMetadata(t *testing.T) {
 	tests := []struct {
-		backend Backend
-		name    string
-		command string
+		backend   Backend
+		name      string
+		command   string
+		skipExact bool // skip exact command match (e.g. minimax uses os.Executable())
 	}{
 		{backend: CodexBackend{}, name: "codex", command: "codex"},
 		{backend: ClaudeBackend{}, name: "claude", command: "claude"},
 		{backend: GeminiBackend{}, name: "gemini", command: "gemini"},
+		{backend: MinimaxBackend{}, name: "minimax", command: "", skipExact: true},
 	}
 
 	for _, tt := range tests {
 		if got := tt.backend.Name(); got != tt.name {
 			t.Fatalf("Name() = %s, want %s", got, tt.name)
 		}
-		if got := tt.backend.Command(); got != tt.command {
-			t.Fatalf("Command() = %s, want %s", got, tt.command)
+		if !tt.skipExact {
+			if got := tt.backend.Command(); got != tt.command {
+				t.Fatalf("Command() = %s, want %s", got, tt.command)
+			}
+		} else {
+			// For backends using os.Executable(), just verify it's non-empty
+			if got := tt.backend.Command(); got == "" {
+				t.Fatalf("Command() returned empty string for %s", tt.name)
+			}
 		}
 	}
 }

--- a/codeagent-wrapper/config.go
+++ b/codeagent-wrapper/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	SkipPermissions    bool
 	MaxParallelWorkers int
 	GeminiModel        string // Gemini model name (empty = use default)
+	MinimaxModel       string // MiniMax model name (empty = use default "MiniMax-M2.5")
 }
 
 // ParallelConfig defines the JSON schema for parallel execution
@@ -62,9 +63,10 @@ type TaskResult struct {
 }
 
 var backendRegistry = map[string]Backend{
-	"codex":  CodexBackend{},
-	"claude": ClaudeBackend{},
-	"gemini": GeminiBackend{},
+	"codex":   CodexBackend{},
+	"claude":  ClaudeBackend{},
+	"gemini":  GeminiBackend{},
+	"minimax": MinimaxBackend{},
 }
 
 func selectBackend(name string) (Backend, error) {
@@ -198,8 +200,9 @@ func parseArgs() (*Config, error) {
 		return nil, fmt.Errorf("task required")
 	}
 
-	// Read environment variable (lowest precedence)
+	// Read environment variables (lowest precedence)
 	geminiModel := strings.TrimSpace(os.Getenv("GEMINI_MODEL"))
+	minimaxModel := strings.TrimSpace(os.Getenv("MINIMAX_MODEL"))
 
 	backendName := defaultBackendName
 	skipPermissions := envFlagEnabled("CODEAGENT_SKIP_PERMISSIONS")
@@ -242,6 +245,24 @@ func parseArgs() (*Config, error) {
 			}
 			geminiModel = value
 			continue
+		case arg == "--minimax-model":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--minimax-model flag requires a non-empty model name")
+			}
+			value := strings.TrimSpace(args[i+1])
+			if value == "" {
+				return nil, fmt.Errorf("--minimax-model flag requires a non-empty model name")
+			}
+			minimaxModel = value
+			i++
+			continue
+		case strings.HasPrefix(arg, "--minimax-model="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--minimax-model="))
+			if value == "" {
+				return nil, fmt.Errorf("--minimax-model flag requires a non-empty model name")
+			}
+			minimaxModel = value
+			continue
 		case arg == "--skip-permissions", arg == "--dangerously-skip-permissions":
 			skipPermissions = true
 			continue
@@ -260,7 +281,7 @@ func parseArgs() (*Config, error) {
 	}
 	args = filtered
 
-	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel}
+	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel, MinimaxModel: minimaxModel}
 	cfg.MaxParallelWorkers = resolveMaxParallelWorkers()
 
 	if args[0] == "resume" {

--- a/codeagent-wrapper/executor.go
+++ b/codeagent-wrapper/executor.go
@@ -985,14 +985,17 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 	//   See: https://github.com/google-gemini/gemini-cli/issues/2493
 	// - Claude: uses cmd.Dir as project context (no .env loading issue).
 	if cfg.Mode != "resume" && cfg.WorkDir != "" {
-		switch commandName {
-		case "codex":
+		switch {
+		case commandName == "codex":
 			// Codex uses -C flag, don't set cmd.Dir
-		case "gemini":
+		case commandName == "gemini":
 			// Use $HOME to avoid project .env interference; project dir passed via --include-directories
 			if home, err := os.UserHomeDir(); err == nil {
 				cmd.SetDir(home)
 			}
+		case cfg.Backend == "minimax":
+			// MiniMax uses self-invocation (--minimax-api); run from WorkDir
+			cmd.SetDir(cfg.WorkDir)
 		default:
 			cmd.SetDir(cfg.WorkDir)
 		}

--- a/codeagent-wrapper/main.go
+++ b/codeagent-wrapper/main.go
@@ -136,6 +136,8 @@ func run() (exitCode int) {
 			return 0
 		case "--cleanup":
 			return runCleanupMode()
+		case "--minimax-api":
+			return runMinimaxAPIMode(os.Args[2:])
 		}
 	}
 
@@ -197,8 +199,9 @@ func run() (exitCode int) {
 			fullOutput := false
 			var extras []string
 
-			// Check for gemini-model in parallel mode
+			// Check for model flags in parallel mode
 			geminiModelInParallel := false
+			minimaxModelInParallel := false
 
 			for i := 0; i < len(args); i++ {
 				arg := args[i]
@@ -224,14 +227,20 @@ func run() (exitCode int) {
 				case arg == "--gemini-model" || strings.HasPrefix(arg, "--gemini-model="):
 					geminiModelInParallel = true
 					continue
+				case arg == "--minimax-model" || strings.HasPrefix(arg, "--minimax-model="):
+					minimaxModelInParallel = true
+					continue
 				default:
 					extras = append(extras, arg)
 				}
 			}
 
-			// Warn about unsupported parameter
+			// Warn about unsupported parameters
 			if geminiModelInParallel {
 				logWarn("--gemini-model parameter is not supported in parallel mode")
+			}
+			if minimaxModelInParallel {
+				logWarn("--minimax-model parameter is not supported in parallel mode")
 			}
 
 			if len(extras) > 0 {
@@ -340,6 +349,12 @@ func run() (exitCode int) {
 			logInfo(fmt.Sprintf("Gemini model from env: %s", cfg.GeminiModel))
 		}
 	}
+	if cfg.MinimaxModel != "" {
+		envModel := strings.TrimSpace(os.Getenv("MINIMAX_MODEL"))
+		if envModel != "" && envModel == cfg.MinimaxModel {
+			logInfo(fmt.Sprintf("MiniMax model from env: %s", cfg.MinimaxModel))
+		}
+	}
 
 	backend, err := selectBackendFn(cfg.Backend)
 	if err != nil {
@@ -365,10 +380,16 @@ func run() (exitCode int) {
 	if cfg.GeminiModel != "" && cfg.Backend == "gemini" {
 		logInfo(fmt.Sprintf("Using Gemini model: %s", cfg.GeminiModel))
 	}
+	if cfg.MinimaxModel != "" && cfg.Backend == "minimax" {
+		logInfo(fmt.Sprintf("Using MiniMax model: %s", cfg.MinimaxModel))
+	}
 
-	// Warn if model parameter used with non-gemini backend
+	// Warn if model parameter used with non-matching backend
 	if cfg.GeminiModel != "" && cfg.Backend != "gemini" {
 		logWarn("--gemini-model parameter is only effective with --backend gemini")
+	}
+	if cfg.MinimaxModel != "" && cfg.Backend != "minimax" {
+		logWarn("--minimax-model parameter is only effective with --backend minimax")
 	}
 
 	timeoutSec := resolveTimeout()
@@ -559,12 +580,16 @@ Parallel mode examples:
     %[1]s --parallel <<'EOF'
 
 Options:
-    --lite, -L            Lite mode: disable Web UI, faster response
-    --backend <name>      Select backend (codex, gemini, claude)
-    --gemini-model <name> Specify Gemini model (gemini backend only)
-                          Can also be set via GEMINI_MODEL environment variable
-                          CLI parameter takes precedence over environment variable
-                          Examples: gemini-2.5-flash, gemini-1.5-pro
+    --lite, -L             Lite mode: disable Web UI, faster response
+    --backend <name>       Select backend (codex, gemini, claude, minimax)
+    --gemini-model <name>  Specify Gemini model (gemini backend only)
+                           Can also be set via GEMINI_MODEL environment variable
+                           CLI parameter takes precedence over environment variable
+                           Examples: gemini-2.5-flash, gemini-1.5-pro
+    --minimax-model <name> Specify MiniMax model (minimax backend only)
+                           Can also be set via MINIMAX_MODEL environment variable
+                           Default: MiniMax-M2.5
+                           Examples: MiniMax-M2.5, MiniMax-M2.5-highspeed
 
 Environment Variables:
     CODEX_TIMEOUT              Timeout in milliseconds (default: 7200000)
@@ -572,6 +597,8 @@ Environment Variables:
     CODEX_DISABLE_SKIP_GIT_CHECK  Disable skip-git-repo-check flag (default: false)
     CODEAGENT_ASCII_MODE       Use ASCII symbols instead of Unicode (PASS/WARN/FAIL)
     CODEAGENT_LITE_MODE        Enable lite mode (true/false)
+    MINIMAX_API_KEY            MiniMax API key (required for minimax backend)
+    MINIMAX_MODEL              Default MiniMax model name
 
 Exit Codes:
     0    Success

--- a/codeagent-wrapper/minimax.go
+++ b/codeagent-wrapper/minimax.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	minimaxAPIURL         = "https://api.minimax.io/v1/chat/completions"
+	minimaxDefaultTemp    = 0.7
+	minimaxRequestTimeout = 300 * time.Second
+)
+
+// runMinimaxAPIMode handles the --minimax-api subcommand.
+// It calls the MiniMax API directly and outputs Gemini-compatible stream-json
+// so the existing parser can consume it without modification.
+func runMinimaxAPIMode(args []string) int {
+	model := defaultMinimaxModel
+	var taskText string
+	readStdin := false
+
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "-m" || args[i] == "--model":
+			if i+1 < len(args) {
+				model = args[i+1]
+				i++
+			}
+		case args[i] == "-p" || args[i] == "--prompt":
+			if i+1 < len(args) {
+				v := args[i+1]
+				i++
+				if v == "-" {
+					readStdin = true
+				} else {
+					taskText = v
+				}
+			}
+		case args[i] == "-":
+			readStdin = true
+		}
+	}
+
+	if readStdin {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "minimax-api: failed to read stdin: %v\n", err)
+			return 1
+		}
+		taskText = string(data)
+	}
+
+	if strings.TrimSpace(taskText) == "" {
+		fmt.Fprintln(os.Stderr, "minimax-api: no task provided")
+		return 1
+	}
+
+	apiKey := os.Getenv("MINIMAX_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "minimax-api: MINIMAX_API_KEY environment variable not set")
+		return 1
+	}
+
+	return callMinimaxAPI(apiKey, model, taskText)
+}
+
+// callMinimaxAPI sends a streaming chat completion request to MiniMax
+// and outputs Gemini-compatible stream-json events to stdout.
+func callMinimaxAPI(apiKey, model, task string) int {
+	// Generate a unique session ID
+	randBytes := make([]byte, 8)
+	_, _ = rand.Read(randBytes)
+	sessionID := fmt.Sprintf("minimax-%s", hex.EncodeToString(randBytes))
+
+	// Emit init event
+	emitEvent(map[string]interface{}{
+		"type":       "init",
+		"session_id": sessionID,
+	})
+
+	// Build request body
+	body := map[string]interface{}{
+		"model": model,
+		"messages": []map[string]string{
+			{"role": "user", "content": task},
+		},
+		"stream":      true,
+		"temperature": minimaxDefaultTemp,
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "minimax-api: failed to marshal request: %v\n", err)
+		return 1
+	}
+
+	req, err := http.NewRequest("POST", minimaxAPIURL, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "minimax-api: failed to create request: %v\n", err)
+		return 1
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: minimaxRequestTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "minimax-api: request failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "minimax-api: API error %d: %s\n", resp.StatusCode, string(respBody))
+		return 1
+	}
+
+	// Parse SSE stream and emit Gemini-compatible events
+	scanner := bufio.NewScanner(resp.Body)
+	// Allow large SSE lines (up to 1MB)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+			content := chunk.Choices[0].Delta.Content
+			delta := true
+			emitEvent(map[string]interface{}{
+				"type":    "content",
+				"role":    "model",
+				"content": content,
+				"delta":   delta,
+			})
+		}
+	}
+
+	// Emit result event
+	emitEvent(map[string]interface{}{
+		"type":       "result",
+		"status":     "success",
+		"session_id": sessionID,
+	})
+
+	return 0
+}
+
+// emitEvent writes a JSON event to stdout (one line per event).
+func emitEvent(event map[string]interface{}) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	fmt.Println(string(data))
+}

--- a/codeagent-wrapper/minimax_test.go
+++ b/codeagent-wrapper/minimax_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// ───────────────────────────────────────────────────────────
+// MinimaxBackend unit tests
+// ───────────────────────────────────────────────────────────
+
+func TestMinimaxBackendMetadata(t *testing.T) {
+	backend := MinimaxBackend{}
+
+	if got := backend.Name(); got != "minimax" {
+		t.Fatalf("Name() = %q, want %q", got, "minimax")
+	}
+
+	cmd := backend.Command()
+	if cmd == "" {
+		t.Fatalf("Command() returned empty string")
+	}
+}
+
+func TestMinimaxBackendBuildArgs(t *testing.T) {
+	backend := MinimaxBackend{}
+
+	t.Run("default model when empty", func(t *testing.T) {
+		cfg := &Config{Mode: "new", WorkDir: "/repo"}
+		got := backend.BuildArgs(cfg, "test task")
+		want := []string{"--minimax-api", "-m", defaultMinimaxModel, "-p", "test task"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("custom model", func(t *testing.T) {
+		cfg := &Config{Mode: "new", MinimaxModel: "MiniMax-M2.5-highspeed"}
+		got := backend.BuildArgs(cfg, "-")
+		want := []string{"--minimax-api", "-m", "MiniMax-M2.5-highspeed", "-p", "-"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("nil config returns nil", func(t *testing.T) {
+		if backend.BuildArgs(nil, "ignored") != nil {
+			t.Fatalf("nil config should return nil args")
+		}
+	})
+}
+
+func TestSelectMinimaxBackend(t *testing.T) {
+	backend, err := selectBackend("minimax")
+	if err != nil {
+		t.Fatalf("selectBackend(minimax) error = %v", err)
+	}
+	if backend.Name() != "minimax" {
+		t.Errorf("expected name minimax, got %s", backend.Name())
+	}
+}
+
+func TestSelectMinimaxBackendCaseInsensitive(t *testing.T) {
+	backend, err := selectBackend("MINIMAX")
+	if err != nil {
+		t.Fatalf("selectBackend(MINIMAX) error = %v", err)
+	}
+	if backend.Name() != "minimax" {
+		t.Errorf("expected name minimax, got %s", backend.Name())
+	}
+}
+
+// ───────────────────────────────────────────────────────────
+// Config parsing tests for --minimax-model
+// ───────────────────────────────────────────────────────────
+
+func TestParseArgsMinimaxModel(t *testing.T) {
+	t.Run("--minimax-model flag", func(t *testing.T) {
+		os.Args = []string{"wrapper", "--minimax-model", "MiniMax-M2.5-highspeed", "--backend", "minimax", "task"}
+		cfg, err := parseArgs()
+		if err != nil {
+			t.Fatalf("parseArgs() error = %v", err)
+		}
+		if cfg.MinimaxModel != "MiniMax-M2.5-highspeed" {
+			t.Fatalf("MinimaxModel = %q, want %q", cfg.MinimaxModel, "MiniMax-M2.5-highspeed")
+		}
+		if cfg.Backend != "minimax" {
+			t.Fatalf("Backend = %q, want %q", cfg.Backend, "minimax")
+		}
+	})
+
+	t.Run("--minimax-model= format", func(t *testing.T) {
+		os.Args = []string{"wrapper", "--minimax-model=MiniMax-M2.5", "task"}
+		cfg, err := parseArgs()
+		if err != nil {
+			t.Fatalf("parseArgs() error = %v", err)
+		}
+		if cfg.MinimaxModel != "MiniMax-M2.5" {
+			t.Fatalf("MinimaxModel = %q, want %q", cfg.MinimaxModel, "MiniMax-M2.5")
+		}
+	})
+
+	t.Run("MINIMAX_MODEL env var", func(t *testing.T) {
+		t.Setenv("MINIMAX_MODEL", "MiniMax-M2.5-highspeed")
+		os.Args = []string{"wrapper", "task"}
+		cfg, err := parseArgs()
+		if err != nil {
+			t.Fatalf("parseArgs() error = %v", err)
+		}
+		if cfg.MinimaxModel != "MiniMax-M2.5-highspeed" {
+			t.Fatalf("MinimaxModel = %q, want %q", cfg.MinimaxModel, "MiniMax-M2.5-highspeed")
+		}
+	})
+
+	t.Run("CLI flag overrides env var", func(t *testing.T) {
+		t.Setenv("MINIMAX_MODEL", "from-env")
+		os.Args = []string{"wrapper", "--minimax-model", "from-cli", "task"}
+		cfg, err := parseArgs()
+		if err != nil {
+			t.Fatalf("parseArgs() error = %v", err)
+		}
+		if cfg.MinimaxModel != "from-cli" {
+			t.Fatalf("MinimaxModel = %q, want %q", cfg.MinimaxModel, "from-cli")
+		}
+	})
+
+	t.Run("--minimax-model without value errors", func(t *testing.T) {
+		os.Args = []string{"wrapper", "--minimax-model"}
+		_, err := parseArgs()
+		if err == nil {
+			t.Fatalf("expected error for --minimax-model without value")
+		}
+	})
+
+	t.Run("--minimax-model= empty value errors", func(t *testing.T) {
+		os.Args = []string{"wrapper", "--minimax-model=", "task"}
+		_, err := parseArgs()
+		if err == nil {
+			t.Fatalf("expected error for --minimax-model= with empty value")
+		}
+	})
+}
+
+// ───────────────────────────────────────────────────────────
+// MiniMax API mode tests (with mock HTTP server)
+// ───────────────────────────────────────────────────────────
+
+func TestRunMinimaxAPIMode_MissingAPIKey(t *testing.T) {
+	t.Setenv("MINIMAX_API_KEY", "")
+	code := runMinimaxAPIMode([]string{"-p", "hello"})
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+func TestRunMinimaxAPIMode_EmptyTask(t *testing.T) {
+	t.Setenv("MINIMAX_API_KEY", "test-key")
+	code := runMinimaxAPIMode([]string{})
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+}
+
+func TestCallMinimaxAPI_MockServerResponseFormat(t *testing.T) {
+	// Create a mock server that returns SSE streaming response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and content type
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		// Verify request body
+		body, _ := io.ReadAll(r.Body)
+		var reqBody map[string]interface{}
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Errorf("failed to parse request body: %v", err)
+		}
+		if reqBody["model"] != "MiniMax-M2.5" {
+			t.Errorf("expected model MiniMax-M2.5, got %v", reqBody["model"])
+		}
+		if reqBody["stream"] != true {
+			t.Errorf("expected stream=true, got %v", reqBody["stream"])
+		}
+
+		// Send SSE response
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+
+		chunks := []string{
+			`data: {"choices":[{"delta":{"content":"Hello"}}]}`,
+			`data: {"choices":[{"delta":{"content":" world"}}]}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			fmt.Fprintln(w, chunk)
+			fmt.Fprintln(w) // empty line between SSE events
+		}
+	}))
+	defer server.Close()
+
+	// Test the mock server response parsing directly
+	reqBody := `{"model":"MiniMax-M2.5","messages":[{"role":"user","content":"test"}],"stream":true}`
+	req, _ := http.NewRequest("POST", server.URL, strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	// Verify the mock returns expected SSE format
+	if !strings.Contains(bodyStr, `"content":"Hello"`) {
+		t.Errorf("expected Hello in response, got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `"content":" world"`) {
+		t.Errorf("expected world in response, got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "[DONE]") {
+		t.Errorf("expected [DONE] in response, got: %s", bodyStr)
+	}
+}
+
+func TestEmitEvent(t *testing.T) {
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	emitEvent(map[string]interface{}{
+		"type":       "init",
+		"session_id": "test-session",
+	})
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	output, _ := io.ReadAll(r)
+	outputStr := strings.TrimSpace(string(output))
+
+	var event map[string]interface{}
+	if err := json.Unmarshal([]byte(outputStr), &event); err != nil {
+		t.Fatalf("failed to parse emitted event: %v", err)
+	}
+
+	if event["type"] != "init" {
+		t.Errorf("expected type=init, got %v", event["type"])
+	}
+	if event["session_id"] != "test-session" {
+		t.Errorf("expected session_id=test-session, got %v", event["session_id"])
+	}
+}
+
+// ───────────────────────────────────────────────────────────
+// Parser integration: Gemini-compatible output from MiniMax
+// ───────────────────────────────────────────────────────────
+
+func TestParserHandlesMinimaxOutput(t *testing.T) {
+	// Simulate the Gemini-compatible stream-json output that MiniMax backend emits
+	events := []string{
+		`{"type":"init","session_id":"minimax-abc123"}`,
+		`{"type":"content","role":"model","content":"Hello ","delta":true}`,
+		`{"type":"content","role":"model","content":"from MiniMax!","delta":true}`,
+		`{"type":"result","status":"success","session_id":"minimax-abc123"}`,
+	}
+
+	input := strings.Join(events, "\n") + "\n"
+	reader := strings.NewReader(input)
+
+	message, threadID := parseJSONStream(reader)
+
+	if message != "Hello from MiniMax!" {
+		t.Errorf("expected message 'Hello from MiniMax!', got %q", message)
+	}
+	if threadID != "minimax-abc123" {
+		t.Errorf("expected threadID 'minimax-abc123', got %q", threadID)
+	}
+}
+
+func TestParserHandlesMinimaxEmptyContent(t *testing.T) {
+	events := []string{
+		`{"type":"init","session_id":"minimax-test"}`,
+		`{"type":"content","role":"model","content":"","delta":true}`,
+		`{"type":"content","role":"model","content":"data","delta":true}`,
+		`{"type":"result","status":"success","session_id":"minimax-test"}`,
+	}
+
+	input := strings.Join(events, "\n") + "\n"
+	reader := strings.NewReader(input)
+
+	message, _ := parseJSONStream(reader)
+
+	if message != "data" {
+		t.Errorf("expected message 'data', got %q", message)
+	}
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@
 export type SupportedLang = 'zh-CN' | 'en'
 
 // 模型类型
-export type ModelType = 'codex' | 'gemini' | 'claude'
+export type ModelType = 'codex' | 'gemini' | 'claude' | 'minimax'
 
 // 协作模式
 export type CollaborationMode = 'parallel' | 'smart' | 'sequential'

--- a/src/utils/installer-template.ts
+++ b/src/utils/installer-template.ts
@@ -79,6 +79,16 @@ export function injectConfigVariables(content: string, config: {
   const liteModeFlag = config.liteMode ? '--lite ' : ''
   processed = processed.replace(/\{\{LITE_MODE_FLAG\}\}/g, liteModeFlag)
 
+  // MiniMax model flag for codeagent-wrapper
+  // Injected when minimax is used as a backend model
+  const minimaxModelFlag = '{{MINIMAX_MODEL_FLAG}}'
+  if (processed.includes(minimaxModelFlag)) {
+    const flag = (routing.backend?.primary === 'minimax' || routing.frontend?.primary === 'minimax')
+      ? '--minimax-model MiniMax-M2.5 '
+      : ''
+    processed = processed.replace(/\{\{MINIMAX_MODEL_FLAG\}\}/g, flag)
+  }
+
   // MCP tool injection based on provider (registry-driven)
   const mcpProvider = config.mcpProvider || 'ace-tool'
   if (mcpProvider === 'skip') {


### PR DESCRIPTION
## Summary

- Adds MiniMax (MiniMax-M2.5 / MiniMax-M2.5-highspeed) as a fourth backend provider alongside Codex, Gemini, and Claude
- Uses a self-invoking pattern: codeagent-wrapper calls itself with `--minimax-api` flag to handle MiniMax API requests directly via SSE streaming
- Outputs Gemini-compatible stream-json format for seamless integration with the existing JSON stream parser

## Changes

### Go (codeagent-wrapper)
- **backend.go**: New `MinimaxBackend` struct implementing the `Backend` interface with `Name()`, `Command()`, `BuildArgs()`
- **minimax.go**: MiniMax API client — parses `-m`/`-p` flags, calls `https://api.minimax.io/v1/chat/completions` with SSE streaming, emits Gemini-compatible JSON events
- **config.go**: `MinimaxModel` field, `minimax` in backend registry, `--minimax-model` flag parsing, `MINIMAX_MODEL` env var
- **main.go**: `--minimax-api` subcommand handler, help text updates, minimax model logging
- **executor.go**: workdir handling for minimax backend

### TypeScript
- **src/types/index.ts**: `minimax` added to `ModelType` union
- **src/utils/installer-template.ts**: `{{MINIMAX_MODEL_FLAG}}` template variable injection

### Tests (16 new tests, all passing)
- `minimax_test.go`: Backend metadata, BuildArgs (default/custom model, nil config), backend registry lookup (case-insensitive), config parsing (6 subtests for flag/env/override/error), API mode error handling, mock HTTP SSE server, emitEvent output, parser integration
- `backend_test.go`: Updated BackendMetadata test to include MinimaxBackend

### Documentation
- Architecture diagram updated to show MiniMax as alternative backend
- Prerequisites table includes MiniMax API Key
- Environment Variables section adds `MINIMAX_API_KEY` and `MINIMAX_MODEL`
- Both English and Chinese READMEs updated

## Test Plan

- [x] All 16 new MiniMax Go tests pass (`go test -run Minimax`)
- [x] All existing Go tests unaffected (3 pre-existing executor test failures unchanged)
- [x] TypeScript tests pass (no regressions from type/template changes)
- [x] `go build` succeeds with no errors
