### PR TITLE
fix: forward --codex-config flags to codex CLI in codeagent-wrapper

### DIFF
--- a/codeagent-wrapper/backend_test.go
+++ b/codeagent-wrapper/backend_test.go
@@ -134,6 +134,64 @@ func TestClaudeBuildArgs_GeminiAndCodexModes(t *testing.T) {
 			t.Fatalf("got %v, want %v", got, want)
 		}
 	})
+
+	t.Run("codex build args forwards --config flags", func(t *testing.T) {
+		t.Setenv("CODEX_REQUIRE_APPROVAL", "")
+
+		backend := CodexBackend{}
+		cfg := &Config{
+			Mode:    "new",
+			WorkDir: "/tmp",
+			CodexConfigFlags: []string{
+				`model_provider="other"`,
+				`model_providers.other.base_url="http://example.com/v1"`,
+			},
+		}
+		got := backend.BuildArgs(cfg, "task")
+		want := []string{
+			"e", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check",
+			"--config", `model_provider="other"`,
+			"--config", `model_providers.other.base_url="http://example.com/v1"`,
+			"-C", "/tmp", "--json", "task",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("codex build args empty config flags does not add --config", func(t *testing.T) {
+		t.Setenv("CODEX_REQUIRE_APPROVAL", "")
+
+		backend := CodexBackend{}
+		cfg := &Config{Mode: "new", WorkDir: "/tmp"}
+		got := backend.BuildArgs(cfg, "task")
+		for _, a := range got {
+			if a == "--config" {
+				t.Fatalf("unexpected --config in args: %v", got)
+			}
+		}
+	})
+
+	t.Run("codex resume mode forwards --config flags", func(t *testing.T) {
+		t.Setenv("CODEX_REQUIRE_APPROVAL", "")
+
+		backend := CodexBackend{}
+		cfg := &Config{
+			Mode:             "resume",
+			SessionID:        "sess-1",
+			WorkDir:          "/tmp",
+			CodexConfigFlags: []string{`model_provider="other"`},
+		}
+		got := backend.BuildArgs(cfg, "follow-up")
+		want := []string{
+			"e", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check",
+			"--config", `model_provider="other"`,
+			"--json", "resume", "sess-1", "follow-up",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
 }
 
 func TestClaudeBuildArgs_BackendMetadata(t *testing.T) {

--- a/codeagent-wrapper/config.go
+++ b/codeagent-wrapper/config.go
@@ -20,7 +20,8 @@ type Config struct {
 	Backend            string
 	SkipPermissions    bool
 	MaxParallelWorkers int
-	GeminiModel        string // Gemini model name (empty = use default)
+	GeminiModel        string   // Gemini model name (empty = use default)
+	CodexConfigFlags   []string // --config key=value pairs forwarded to codex CLI
 }
 
 // ParallelConfig defines the JSON schema for parallel execution
@@ -203,6 +204,19 @@ func parseArgs() (*Config, error) {
 
 	backendName := defaultBackendName
 	skipPermissions := envFlagEnabled("CODEAGENT_SKIP_PERMISSIONS")
+	var codexConfigFlags []string
+
+	// Parse CODEX_CONFIG env var: semicolon-separated key=value pairs
+	// e.g. CODEX_CONFIG='model_provider="other";model_providers.other.base_url="http://..."'
+	if envCfg := strings.TrimSpace(os.Getenv("CODEX_CONFIG")); envCfg != "" {
+		for _, entry := range strings.Split(envCfg, ";") {
+			entry = strings.TrimSpace(entry)
+			if entry != "" && strings.Contains(entry, "=") {
+				codexConfigFlags = append(codexConfigFlags, entry)
+			}
+		}
+	}
+
 	filtered := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -242,6 +256,24 @@ func parseArgs() (*Config, error) {
 			}
 			geminiModel = value
 			continue
+		case arg == "--codex-config":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--codex-config flag requires a key=value argument")
+			}
+			value := strings.TrimSpace(args[i+1])
+			if value == "" || !strings.Contains(value, "=") {
+				return nil, fmt.Errorf("--codex-config flag requires a key=value argument")
+			}
+			codexConfigFlags = append(codexConfigFlags, value)
+			i++
+			continue
+		case strings.HasPrefix(arg, "--codex-config="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--codex-config="))
+			if value == "" || !strings.Contains(value, "=") {
+				return nil, fmt.Errorf("--codex-config flag requires a key=value argument")
+			}
+			codexConfigFlags = append(codexConfigFlags, value)
+			continue
 		case arg == "--skip-permissions", arg == "--dangerously-skip-permissions":
 			skipPermissions = true
 			continue
@@ -260,7 +292,7 @@ func parseArgs() (*Config, error) {
 	}
 	args = filtered
 
-	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel}
+	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel, CodexConfigFlags: codexConfigFlags}
 	cfg.MaxParallelWorkers = resolveMaxParallelWorkers()
 
 	if args[0] == "resume" {

--- a/codeagent-wrapper/executor.go
+++ b/codeagent-wrapper/executor.go
@@ -782,6 +782,11 @@ func buildCodexArgs(cfg *Config, targetArg string) []string {
 		args = append(args, "--skip-git-repo-check")
 	}
 
+	// Forward --config key=value pairs to codex CLI (e.g. model_provider, base_url)
+	for _, cfgFlag := range cfg.CodexConfigFlags {
+		args = append(args, "--config", cfgFlag)
+	}
+
 	if isResume {
 		return append(args,
 			"--json",

--- a/codeagent-wrapper/main.go
+++ b/codeagent-wrapper/main.go
@@ -565,11 +565,18 @@ Options:
                           Can also be set via GEMINI_MODEL environment variable
                           CLI parameter takes precedence over environment variable
                           Examples: gemini-2.5-flash, gemini-1.5-pro
+    --codex-config k=v    Pass --config key=value to codex CLI (repeatable)
+                          Can also be set via CODEX_CONFIG env var (semicolon-separated)
+                          Examples:
+                            --codex-config 'model_provider="other"'
+                            --codex-config 'model_providers.other.base_url="http://host/v1"'
 
 Environment Variables:
     CODEX_TIMEOUT              Timeout in milliseconds (default: 7200000)
     CODEX_REQUIRE_APPROVAL     Require manual approval for file operations (default: false)
     CODEX_DISABLE_SKIP_GIT_CHECK  Disable skip-git-repo-check flag (default: false)
+    CODEX_CONFIG               Semicolon-separated codex --config flags
+                               Example: model_provider="other";model_providers.other.base_url="http://..."
     CODEAGENT_ASCII_MODE       Use ASCII symbols instead of Unicode (PASS/WARN/FAIL)
     CODEAGENT_LITE_MODE        Enable lite mode (true/false)
 

--- a/codeagent-wrapper/main_test.go
+++ b/codeagent-wrapper/main_test.go
@@ -1196,6 +1196,86 @@ func TestBackendParseArgs_SkipPermissions(t *testing.T) {
 	}
 }
 
+func TestParseArgs_CodexConfigFlag(t *testing.T) {
+	t.Cleanup(func() { os.Unsetenv("CODEX_CONFIG") })
+	os.Unsetenv("CODEX_CONFIG")
+
+	// --codex-config with space-separated value
+	os.Args = []string{"codeagent-wrapper", "--codex-config", `model_provider="other"`, "task"}
+	cfg, err := parseArgs()
+	if err != nil {
+		t.Fatalf("parseArgs() unexpected error: %v", err)
+	}
+	if len(cfg.CodexConfigFlags) != 1 || cfg.CodexConfigFlags[0] != `model_provider="other"` {
+		t.Fatalf("CodexConfigFlags = %v, want [model_provider=\"other\"]", cfg.CodexConfigFlags)
+	}
+
+	// --codex-config= form
+	os.Args = []string{"codeagent-wrapper", `--codex-config=model_provider="other"`, "task"}
+	cfg, err = parseArgs()
+	if err != nil {
+		t.Fatalf("parseArgs() unexpected error: %v", err)
+	}
+	if len(cfg.CodexConfigFlags) != 1 || cfg.CodexConfigFlags[0] != `model_provider="other"` {
+		t.Fatalf("CodexConfigFlags = %v, want [model_provider=\"other\"]", cfg.CodexConfigFlags)
+	}
+
+	// Multiple --codex-config flags
+	os.Args = []string{"codeagent-wrapper",
+		"--codex-config", `model_provider="other"`,
+		"--codex-config", `model_providers.other.base_url="http://host/v1"`,
+		"task",
+	}
+	cfg, err = parseArgs()
+	if err != nil {
+		t.Fatalf("parseArgs() unexpected error: %v", err)
+	}
+	if len(cfg.CodexConfigFlags) != 2 {
+		t.Fatalf("CodexConfigFlags length = %d, want 2", len(cfg.CodexConfigFlags))
+	}
+
+	// Missing value after --codex-config
+	os.Args = []string{"codeagent-wrapper", "--codex-config"}
+	_, err = parseArgs()
+	if err == nil {
+		t.Fatal("expected error for --codex-config without value")
+	}
+
+	// Invalid value (no = sign)
+	os.Args = []string{"codeagent-wrapper", "--codex-config", "invalid", "task"}
+	_, err = parseArgs()
+	if err == nil {
+		t.Fatal("expected error for --codex-config without key=value")
+	}
+}
+
+func TestParseArgs_CodexConfigEnvVar(t *testing.T) {
+	t.Cleanup(func() { os.Unsetenv("CODEX_CONFIG") })
+
+	os.Setenv("CODEX_CONFIG", `model_provider="other";model_providers.other.base_url="http://host/v1"`)
+	os.Args = []string{"codeagent-wrapper", "task"}
+	cfg, err := parseArgs()
+	if err != nil {
+		t.Fatalf("parseArgs() unexpected error: %v", err)
+	}
+	if len(cfg.CodexConfigFlags) != 2 {
+		t.Fatalf("CodexConfigFlags length = %d, want 2; got %v", len(cfg.CodexConfigFlags), cfg.CodexConfigFlags)
+	}
+	if cfg.CodexConfigFlags[0] != `model_provider="other"` {
+		t.Fatalf("CodexConfigFlags[0] = %q, want model_provider=\"other\"", cfg.CodexConfigFlags[0])
+	}
+
+	// CLI flags append to env var entries
+	os.Args = []string{"codeagent-wrapper", "--codex-config", `extra="val"`, "task"}
+	cfg, err = parseArgs()
+	if err != nil {
+		t.Fatalf("parseArgs() unexpected error: %v", err)
+	}
+	if len(cfg.CodexConfigFlags) != 3 {
+		t.Fatalf("CodexConfigFlags length = %d, want 3; got %v", len(cfg.CodexConfigFlags), cfg.CodexConfigFlags)
+	}
+}
+
 func TestBackendParseBoolFlag(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- codeagent-wrapper 调用 `codex e ...` 时不传递 `--config` 参数，导致无法配置自定义 `model_provider` 或 `base_url`（如使用非官方 API 端点时必然失败）
- 新增 `--codex-config key=value` CLI 参数（可重复）和 `CODEX_CONFIG` 环境变量（分号分隔），将 `--config` 透传给 codex CLI
- 用法示例：
  ```bash
  # CLI 方式
  codeagent-wrapper --codex-config 'model_provider="other"' \
                    --codex-config 'model_providers.other.base_url="http://host/v1"' \
                    "task"

  # 环境变量方式（适用于 /ccg: slash 命令）
  export CODEX_CONFIG='model_provider="other";model_providers.other.base_url="http://host/v1"'
  codeagent-wrapper "task"
  ```

## Changes

| 文件 | 改动 |
|------|------|
| `config.go` | Config 结构体新增 `CodexConfigFlags`，`parseArgs()` 解析 `--codex-config` + `CODEX_CONFIG` 环境变量 |
| `executor.go` | `buildCodexArgs()` 遍历 `CodexConfigFlags` 注入 `--config` 参数 |
| `main.go` | 帮助文本新增 `--codex-config` 和 `CODEX_CONFIG` 说明 |
| `backend_test.go` | 3 个测试：config 转发、空 config、resume 模式转发 |
| `main_test.go` | 2 个测试：CLI flag 解析 + 环境变量解析 |

## Test plan

- [x] `go test -run TestParseArgs_CodexConfig` 通过（5 个子用例）
- [x] `go test -run TestClaudeBuildArgs_GeminiAndCodexModes` 通过（含 3 个新增子用例）
- [x] 编译后手动验证 `--codex-config` 和 `CODEX_CONFIG` 环境变量均能正确注入 `--config` 到 codex 命令行
- [x] codex 端确认收到 `--config` 后正常执行任务