### PR TITLE
fix: update ace-tool proxy URL to include /relay/ path

### DIFF
--- a/src/commands/config-mcp.ts
+++ b/src/commands/config-mcp.ts
@@ -98,7 +98,7 @@ async function handleInstallAceTool(isRs: boolean): Promise<void> {
   console.log()
   console.log(ansis.cyan(`📖 获取 ${toolName} 访问方式：`))
   console.log(`   ${ansis.gray('•')} ${ansis.cyan('官方服务')}: ${ansis.underline('https://augmentcode.com/')}`)
-  console.log(`   ${ansis.gray('•')} ${ansis.cyan('第三方中转')} ${ansis.green('(推荐)')}: ${ansis.underline('https://acemcp.heroman.wtf/')}`)
+  console.log(`   ${ansis.gray('•')} ${ansis.cyan('第三方中转')} ${ansis.green('(推荐)')}: ${ansis.underline('https://acemcp.heroman.wtf/relay/')}`)
   console.log(`   ${ansis.gray('⚠')} ${ansis.yellow('注意')}: enhance_prompt 已不可用，search_context 代码检索正常`)
   console.log()
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -330,7 +330,7 @@ export async function init(options: InitOptions = {}): Promise<void> {
       console.log(ansis.cyan.bold(`  🔧 ace-tool MCP`))
       console.log()
       console.log(`     ${ansis.gray('•')} ${ansis.cyan(i18n.t('init:mcp.officialService'))}: ${ansis.underline('https://augmentcode.com/')}`)
-      console.log(`     ${ansis.gray('•')} ${ansis.cyan(i18n.t('init:mcp.proxyService'))} ${ansis.yellow(`(${i18n.t('init:mcp.noSignup')})`)}: ${ansis.underline('https://acemcp.heroman.wtf/')}`)
+      console.log(`     ${ansis.gray('•')} ${ansis.cyan(i18n.t('init:mcp.proxyService'))} ${ansis.yellow(`(${i18n.t('init:mcp.noSignup')})`)}: ${ansis.underline('https://acemcp.heroman.wtf/relay/')}`)
       console.log()
 
       const aceAnswers = await inquirer.prompt([
@@ -879,7 +879,7 @@ export async function init(options: InitOptions = {}): Promise<void> {
       console.log(`     ${ansis.green('2.')} ${ansis.cyan('ace-tool / ace-tool-rs')}: ${ansis.underline('https://augmentcode.com/')}`)
       console.log(`        ${ansis.gray(i18n.t('init:mcp.promptEnhancement'))}`)
       console.log()
-      console.log(`     ${ansis.green('3.')} ${ansis.cyan('ace-tool ' + i18n.t('init:mcp.proxyService'))} ${ansis.yellow(`(${i18n.t('init:mcp.noSignup')})`)}: ${ansis.underline('https://acemcp.heroman.wtf/')}`)
+      console.log(`     ${ansis.green('3.')} ${ansis.cyan('ace-tool ' + i18n.t('init:mcp.proxyService'))} ${ansis.yellow(`(${i18n.t('init:mcp.noSignup')})`)}: ${ansis.underline('https://acemcp.heroman.wtf/relay/')}`)
       console.log(`        ${ansis.gray(i18n.t('init:mcp.communityProxy'))}`)
       console.log()
       console.log(`     ${ansis.green('4.')} ${ansis.cyan('ContextWeaver')} ${ansis.yellow(`(${i18n.t('init:mcp.freeQuota')})`)}: ${ansis.underline('https://siliconflow.cn/')}`)


### PR DESCRIPTION
## Summary

- 安装时显示的 ace-tool 第三方中转地址缺少 `/relay/` 后缀
- 用户复制提示中的地址 `https://acemcp.heroman.wtf/` 作为 Base URL 会导致连接失败
- 修正为 `https://acemcp.heroman.wtf/relay/`，共 3 处（`config-mcp.ts` 1 处，`init.ts` 2 处）

## Test plan

- [x] `pnpm build` 通过
- [x] `pnpm test` 135 tests 全部通过
- [x] 本地运行 `node bin/ccg.mjs` → 主菜单 → 配置 MCP → ace-tool，确认提示地址已修正为 `https://acemcp.heroman.wtf/relay/`
- [x] 使用修正后的地址配置成功，MCP 同步到 Codex + Gemini 正常

## 验证结果

```
📖 获取 ace-tool 访问方式：
   • 官方服务: https://augmentcode.com/
   • 第三方中转 (推荐): https://acemcp.heroman.wtf/relay/
   ⚠ 注意: enhance_prompt 已不可用，search_context 代码检索正常

✔ Base URL (中转服务必填，官方留空) https://acemcp.heroman.wtf/relay/
✔ Token (必填)

✓ ace-tool MCP 配置成功！
✓ MCP 已同步到 Codex + Gemini
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)