### PR TITLE
Add opencode backend support

### DIFF
--- a/codeagent-wrapper/backend.go
+++ b/codeagent-wrapper/backend.go
@@ -117,6 +117,49 @@ func (GeminiBackend) BuildArgs(cfg *Config, targetArg string) []string {
 	return buildGeminiArgs(cfg, targetArg)
 }
 
+type OpencodeBackend struct{}
+
+func (OpencodeBackend) Name() string { return "opencode" }
+func (OpencodeBackend) Command() string {
+	return "opencode"
+}
+func (OpencodeBackend) BuildArgs(cfg *Config, targetArg string) []string {
+	return buildOpencodeArgs(cfg, targetArg)
+}
+
+func buildOpencodeArgs(cfg *Config, targetArg string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	args := []string{"run", "--format", "json"}
+
+	if cfg.SkipPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+
+	if model := strings.TrimSpace(cfg.OpencodeModel); model != "" {
+		args = append(args, "-m", model)
+	}
+
+	if cfg.Mode == "resume" && cfg.SessionID != "" {
+		args = append(args, "--session", cfg.SessionID)
+	}
+
+	if cfg.WorkDir != "" {
+		args = append(args, "--dir", cfg.WorkDir)
+	}
+
+	opencodeServerURL := strings.TrimSpace(os.Getenv("OPENCODE_SERVER_URL"))
+	if opencodeServerURL != "" && envFlagEnabled("CODEAGENT_OPENCODE_ATTACH") {
+		args = append(args, "--attach", opencodeServerURL)
+	}
+
+	args = append(args, targetArg)
+
+	return args
+}
+
 func buildGeminiArgs(cfg *Config, targetArg string) []string {
 	if cfg == nil {
 		return nil

--- a/codeagent-wrapper/backend_test.go
+++ b/codeagent-wrapper/backend_test.go
@@ -111,6 +111,44 @@ func TestClaudeBuildArgs_GeminiAndCodexModes(t *testing.T) {
 		}
 	})
 
+	t.Run("opencode new mode includes model permissions dir and attach", func(t *testing.T) {
+		t.Setenv("OPENCODE_SERVER_URL", "http://localhost:58656")
+		t.Setenv("CODEAGENT_OPENCODE_ATTACH", "true")
+
+		backend := OpencodeBackend{}
+		cfg := &Config{Mode: "new", WorkDir: "/workspace", SkipPermissions: true, OpencodeModel: "zhoumo/glm-5.1"}
+		got := backend.BuildArgs(cfg, "hello")
+		want := []string{"run", "--format", "json", "--dangerously-skip-permissions", "-m", "zhoumo/glm-5.1", "--dir", "/workspace", "--attach", "http://localhost:58656", "hello"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("opencode server env alone uses standalone mode", func(t *testing.T) {
+		t.Setenv("OPENCODE_SERVER_URL", "http://localhost:58656")
+		t.Setenv("CODEAGENT_OPENCODE_ATTACH", "")
+
+		backend := OpencodeBackend{}
+		cfg := &Config{Mode: "new", WorkDir: "/workspace", SkipPermissions: true, OpencodeModel: "zhoumo/glm-5.1"}
+		got := backend.BuildArgs(cfg, "hello")
+		want := []string{"run", "--format", "json", "--dangerously-skip-permissions", "-m", "zhoumo/glm-5.1", "--dir", "/workspace", "hello"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("opencode resume mode includes session", func(t *testing.T) {
+		t.Setenv("OPENCODE_SERVER_URL", "")
+
+		backend := OpencodeBackend{}
+		cfg := &Config{Mode: "resume", SessionID: "ses_123", WorkDir: "/workspace"}
+		got := backend.BuildArgs(cfg, "continue")
+		want := []string{"run", "--format", "json", "--session", "ses_123", "--dir", "/workspace", "continue"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
 	t.Run("codex build args includes bypass by default (CODEX_REQUIRE_APPROVAL unset)", func(t *testing.T) {
 		t.Setenv("CODEX_REQUIRE_APPROVAL", "")
 
@@ -216,6 +254,7 @@ func TestClaudeBuildArgs_BackendMetadata(t *testing.T) {
 		{backend: CodexBackend{}, name: "codex", command: "codex"},
 		{backend: ClaudeBackend{}, name: "claude", command: "claude"},
 		{backend: GeminiBackend{}, name: "gemini", command: "gemini"},
+		{backend: OpencodeBackend{}, name: "opencode", command: "opencode"},
 	}
 
 	for _, tt := range tests {

--- a/codeagent-wrapper/config.go
+++ b/codeagent-wrapper/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	SkipPermissions    bool
 	MaxParallelWorkers int
 	GeminiModel        string // Gemini model name (empty = use default)
+	OpencodeModel      string // Opencode model name in provider/model format (empty = use default)
 	Progress           bool   // Emit compact progress lines to stderr
 }
 
@@ -32,16 +33,19 @@ type ParallelConfig struct {
 
 // TaskSpec describes an individual task entry in the parallel config
 type TaskSpec struct {
-	ID           string          `json:"id"`
-	Task         string          `json:"task"`
-	WorkDir      string          `json:"workdir,omitempty"`
-	Dependencies []string        `json:"dependencies,omitempty"`
-	SessionID    string          `json:"session_id,omitempty"`
-	Backend      string          `json:"backend,omitempty"`
-	Progress     bool            `json:"-"`
-	Mode         string          `json:"-"`
-	UseStdin     bool            `json:"-"`
-	Context      context.Context `json:"-"`
+	ID              string          `json:"id"`
+	Task            string          `json:"task"`
+	WorkDir         string          `json:"workdir,omitempty"`
+	Dependencies    []string        `json:"dependencies,omitempty"`
+	SessionID       string          `json:"session_id,omitempty"`
+	Backend         string          `json:"backend,omitempty"`
+	Progress        bool            `json:"-"`
+	Mode            string          `json:"-"`
+	UseStdin        bool            `json:"-"`
+	SkipPermissions bool            `json:"-"`
+	GeminiModel     string          `json:"-"`
+	OpencodeModel   string          `json:"-"`
+	Context         context.Context `json:"-"`
 }
 
 // TaskResult captures the execution outcome of a task
@@ -64,9 +68,10 @@ type TaskResult struct {
 }
 
 var backendRegistry = map[string]Backend{
-	"codex":  CodexBackend{},
-	"claude": ClaudeBackend{},
-	"gemini": GeminiBackend{},
+	"codex":    CodexBackend{},
+	"claude":   ClaudeBackend{},
+	"gemini":   GeminiBackend{},
+	"opencode": OpencodeBackend{},
 }
 
 func selectBackend(name string) (Backend, error) {
@@ -202,6 +207,7 @@ func parseArgs() (*Config, error) {
 
 	// Read environment variable (lowest precedence)
 	geminiModel := strings.TrimSpace(os.Getenv("GEMINI_MODEL"))
+	opencodeModel := strings.TrimSpace(os.Getenv("OPENCODE_MODEL"))
 
 	backendName := defaultBackendName
 	skipPermissions := envFlagEnabled("CODEAGENT_SKIP_PERMISSIONS")
@@ -245,6 +251,24 @@ func parseArgs() (*Config, error) {
 			}
 			geminiModel = value
 			continue
+		case arg == "--opencode-model":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--opencode-model flag requires a non-empty model name")
+			}
+			value := strings.TrimSpace(args[i+1])
+			if value == "" {
+				return nil, fmt.Errorf("--opencode-model flag requires a non-empty model name")
+			}
+			opencodeModel = value
+			i++
+			continue
+		case strings.HasPrefix(arg, "--opencode-model="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--opencode-model="))
+			if value == "" {
+				return nil, fmt.Errorf("--opencode-model flag requires a non-empty model name")
+			}
+			opencodeModel = value
+			continue
 		case arg == "--skip-permissions", arg == "--dangerously-skip-permissions":
 			skipPermissions = true
 			continue
@@ -266,7 +290,7 @@ func parseArgs() (*Config, error) {
 	}
 	args = filtered
 
-	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel, Progress: progress}
+	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel, OpencodeModel: opencodeModel, Progress: progress}
 	cfg.MaxParallelWorkers = resolveMaxParallelWorkers()
 
 	if args[0] == "resume" {

--- a/codeagent-wrapper/executor.go
+++ b/codeagent-wrapper/executor.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const envUnsetValue = "\x00CODEAGENT_UNSET_ENV"
+
 // resolvePostMessageDelay returns the delay duration after receiving agent_message
 // before terminating the backend process. This delay allows the backend to send
 // completion events (turn.completed/thread.completed) which may arrive after the message.
@@ -141,10 +143,15 @@ func (r *realCmd) SetEnv(env map[string]string) {
 		merged[kv[:idx]] = kv[idx+1:]
 	}
 	for k, v := range env {
-		if strings.TrimSpace(k) == "" {
+		key := strings.TrimSpace(k)
+		if key == "" {
 			continue
 		}
-		merged[k] = v
+		if v == envUnsetValue {
+			delete(merged, key)
+			continue
+		}
+		merged[key] = v
 	}
 
 	keys := make([]string, 0, len(merged))
@@ -165,6 +172,42 @@ func (r *realCmd) Process() processHandle {
 		return nil
 	}
 	return &realProcess{proc: r.cmd.Process}
+}
+
+func isolateOpencodeProcess(cmd commandRunner) {
+	rc, ok := cmd.(*realCmd)
+	if !ok || rc == nil || rc.cmd == nil {
+		return
+	}
+	isolateOpencodeExecCmd(rc.cmd)
+}
+
+func opencodeEnvOverrides() map[string]string {
+	env := make(map[string]string)
+	for _, kv := range os.Environ() {
+		idx := strings.IndexByte(kv, '=')
+		if idx <= 0 {
+			continue
+		}
+		key := kv[:idx]
+		if shouldUnsetOpencodeEnv(key) {
+			env[key] = envUnsetValue
+		}
+	}
+	return env
+}
+
+func shouldUnsetOpencodeEnv(key string) bool {
+	key = strings.ToUpper(strings.TrimSpace(key))
+	if !strings.HasPrefix(key, "OPENCODE_") {
+		return false
+	}
+	for _, marker := range []string{"SESSION", "PARENT", "RUN", "CLIENT", "INSTANCE"} {
+		if strings.Contains(key, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // realProcess implements processHandle using os.Process
@@ -820,12 +863,15 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 	logger := injectedLogger
 
 	cfg := &Config{
-		Mode:      taskSpec.Mode,
-		Task:      taskSpec.Task,
-		SessionID: taskSpec.SessionID,
-		WorkDir:   taskSpec.WorkDir,
-		Backend:   defaultBackendName,
-		Progress:  taskSpec.Progress,
+		Mode:            taskSpec.Mode,
+		Task:            taskSpec.Task,
+		SessionID:       taskSpec.SessionID,
+		WorkDir:         taskSpec.WorkDir,
+		Backend:         defaultBackendName,
+		SkipPermissions: taskSpec.SkipPermissions,
+		GeminiModel:     taskSpec.GeminiModel,
+		OpencodeModel:   taskSpec.OpencodeModel,
+		Progress:        taskSpec.Progress,
 	}
 
 	commandName := codexCommand
@@ -863,11 +909,16 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 	// Use stdin pipe instead and omit -p so Gemini reads from piped stdin.
 	geminiDirect := useStdin && cfg.Backend == "gemini" && !isWindows()
 	geminiStdinPipe := useStdin && cfg.Backend == "gemini" && isWindows()
-	if useStdin && !geminiDirect && !geminiStdinPipe {
+	// Opencode CLI passes prompt as the last positional argument, not via stdin.
+	opencodeDirect := useStdin && cfg.Backend == "opencode"
+	if useStdin && !geminiDirect && !geminiStdinPipe && !opencodeDirect {
 		targetArg = "-"
 	}
 	if geminiStdinPipe {
 		targetArg = "" // signal buildGeminiArgs to omit -p flag
+	}
+	if opencodeDirect {
+		targetArg = taskSpec.Task
 	}
 
 	var codexArgs []string
@@ -980,12 +1031,20 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 	}
 
 	cmd := newCommandRunner(ctx, commandName, codexArgs...)
+	if cfg.Backend == "opencode" {
+		isolateOpencodeProcess(cmd)
+	}
 
 	// 统一处理所有后端的环境变量
 	// 修复 Windows Git Bash 后台进程 PATH 继承问题
 	env := loadMinimalEnvSettings()
 	if env == nil {
 		env = make(map[string]string)
+	}
+	if cfg.Backend == "opencode" {
+		for k, v := range opencodeEnvOverrides() {
+			env[k] = v
+		}
 	}
 	cmd.SetEnv(env) // SetEnv 会自动合并 os.Environ() (executor.go:122-161)
 
@@ -1001,6 +1060,8 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 		switch commandName {
 		case "codex":
 			// Codex uses -C flag, don't set cmd.Dir
+		case "opencode":
+			// Opencode uses --dir flag in BuildArgs, don't set cmd.Dir
 		default:
 			cmd.SetDir(cfg.WorkDir)
 		}
@@ -1026,7 +1087,7 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 
 	var stdinPipe io.WriteCloser
 	var err error
-	if useStdin && !geminiDirect {
+	if useStdin && !geminiDirect && !opencodeDirect {
 		stdinPipe, err = cmd.StdinPipe()
 		if err != nil {
 			logErrorFn("Failed to create stdin pipe: " + err.Error())
@@ -1285,6 +1346,8 @@ waitLoop:
 	if waitErr != nil {
 		if forcedAfterComplete && parsed.message != "" {
 			logWarnFn(fmt.Sprintf("%s terminated after delivering output", commandName))
+		} else if cfg.Backend == "opencode" && parsed.message != "" {
+			logWarnFn(fmt.Sprintf("%s exited (opencode backend, message captured, ignoring exit code)", commandName))
 		} else {
 			if exitErr, ok := waitErr.(*exec.ExitError); ok {
 				code := exitErr.ExitCode()

--- a/codeagent-wrapper/executor_concurrent_test.go
+++ b/codeagent-wrapper/executor_concurrent_test.go
@@ -152,6 +152,44 @@ func (f *execFakeRunner) Process() processHandle {
 }
 
 func TestExecutorHelperCoverage(t *testing.T) {
+	t.Run("opencodeOptionsReachChildProcess", func(t *testing.T) {
+		defer resetTestHooks()
+		t.Setenv("OPENCODE_SERVER_URL", "http://localhost:58656")
+		t.Setenv("OPENCODE_SESSION_ID", "ses_parent")
+
+		var gotName string
+		var gotArgs []string
+		var rc *execFakeRunner
+		newCommandRunner = func(ctx context.Context, name string, args ...string) commandRunner {
+			gotName = name
+			gotArgs = append([]string(nil), args...)
+			rc = &execFakeRunner{
+				stdout:  newReasonReadCloser(`{"type":"text","sessionID":"ses_child","part":{"type":"text","text":"ok","sessionID":"ses_child"}}`),
+				process: &execFakeProcess{pid: 15},
+			}
+			return rc
+		}
+
+		res := runCodexTaskWithContext(context.Background(), TaskSpec{
+			Task:            "hello",
+			WorkDir:         "/workspace",
+			Mode:            "new",
+			Backend:         "opencode",
+			SkipPermissions: true,
+			OpencodeModel:   "zhoumo/glm-5.1",
+		}, OpencodeBackend{}, nil, false, true, 1)
+		if res.ExitCode != 0 || res.Message != "ok" {
+			t.Fatalf("unexpected result: %+v", res)
+		}
+		wantArgs := []string{"run", "--format", "json", "--dangerously-skip-permissions", "-m", "zhoumo/glm-5.1", "--dir", "/workspace", "hello"}
+		if gotName != "opencode" || !slices.Equal(gotArgs, wantArgs) {
+			t.Fatalf("command = %s %v, want opencode %v", gotName, gotArgs, wantArgs)
+		}
+		if rc == nil || rc.env["OPENCODE_SESSION_ID"] != envUnsetValue {
+			t.Fatalf("expected parent opencode session env to be unset, got %+v", rc)
+		}
+	})
+
 	t.Run("realCmdAndProcess", func(t *testing.T) {
 		rc := &realCmd{}
 		if err := rc.Start(); err == nil {

--- a/codeagent-wrapper/main.go
+++ b/codeagent-wrapper/main.go
@@ -365,10 +365,16 @@ func run() (exitCode int) {
 	if cfg.GeminiModel != "" && cfg.Backend == "gemini" {
 		logInfo(fmt.Sprintf("Using Gemini model: %s", cfg.GeminiModel))
 	}
+	if cfg.OpencodeModel != "" && cfg.Backend == "opencode" {
+		logInfo(fmt.Sprintf("Using Opencode model: %s", cfg.OpencodeModel))
+	}
 
 	// Warn if model parameter used with non-gemini backend
 	if cfg.GeminiModel != "" && cfg.Backend != "gemini" {
 		logWarn("--gemini-model parameter is only effective with --backend gemini")
+	}
+	if cfg.OpencodeModel != "" && cfg.Backend != "opencode" {
+		logWarn("--opencode-model parameter is only effective with --backend opencode")
 	}
 
 	timeoutSec := resolveTimeout()
@@ -417,14 +423,18 @@ func run() (exitCode int) {
 	useStdin := cfg.ExplicitStdin || shouldUseStdin(taskText, piped)
 
 	targetArg := taskText
-	// Match the geminiDirect/geminiStdinPipe logic in executor.go so the display is accurate.
+	// Match the geminiDirect/geminiStdinPipe/opencodeDirect logic in executor.go
 	geminiDirect := useStdin && cfg.Backend == "gemini" && !isWindows()
 	geminiStdinPipe := useStdin && cfg.Backend == "gemini" && isWindows()
-	if useStdin && !geminiDirect && !geminiStdinPipe {
+	opencodeDirect := useStdin && cfg.Backend == "opencode"
+	if useStdin && !geminiDirect && !geminiStdinPipe && !opencodeDirect {
 		targetArg = "-"
 	}
 	if geminiStdinPipe {
 		targetArg = ""
+	}
+	if opencodeDirect {
+		targetArg = taskText
 	}
 	codexArgs := buildCodexArgsFn(cfg, targetArg)
 
@@ -472,12 +482,16 @@ func run() (exitCode int) {
 	logInfo(fmt.Sprintf("%s running...", cfg.Backend))
 
 	taskSpec := TaskSpec{
-		Task:      taskText,
-		WorkDir:   cfg.WorkDir,
-		Mode:      cfg.Mode,
-		SessionID: cfg.SessionID,
-		UseStdin:  useStdin,
-		Progress:  cfg.Progress,
+		Task:            taskText,
+		WorkDir:         cfg.WorkDir,
+		Mode:            cfg.Mode,
+		SessionID:       cfg.SessionID,
+		Backend:         cfg.Backend,
+		UseStdin:        useStdin,
+		SkipPermissions: cfg.SkipPermissions,
+		GeminiModel:     cfg.GeminiModel,
+		OpencodeModel:   cfg.OpencodeModel,
+		Progress:        cfg.Progress,
 	}
 
 	result := runTaskFn(taskSpec, false, cfg.Timeout)
@@ -567,11 +581,15 @@ Parallel mode examples:
 
 Options:
     --lite, -L            Lite mode: disable Web UI, faster response
-    --backend <name>      Select backend (codex, gemini, claude)
+    --backend <name>      Select backend (codex, gemini, claude, opencode)
     --gemini-model <name> Specify Gemini model (gemini backend only)
                           Can also be set via GEMINI_MODEL environment variable
                           CLI parameter takes precedence over environment variable
                           Examples: gemini-2.5-flash, gemini-1.5-pro
+    --opencode-model <name> Specify Opencode model in provider/model format (opencode backend only)
+                          Can also be set via OPENCODE_MODEL environment variable
+                          CLI parameter takes precedence over environment variable
+                          Examples: zhoumo/glm-5.1, anthropic/claude-sonnet-4-6
     --progress            Emit compact progress lines to stderr during execution
 
 Environment Variables:
@@ -580,6 +598,9 @@ Environment Variables:
     CODEX_DISABLE_SKIP_GIT_CHECK  Disable skip-git-repo-check flag (default: false)
     CODEAGENT_ASCII_MODE       Use ASCII symbols instead of Unicode (PASS/WARN/FAIL)
     CODEAGENT_LITE_MODE        Enable lite mode (true/false)
+    CODEAGENT_OPENCODE_ATTACH  Attach opencode to OPENCODE_SERVER_URL (true/false, default: false)
+    OPENCODE_MODEL             Model for opencode backend in provider/model format
+    OPENCODE_SERVER_URL        Opencode server URL used when CODEAGENT_OPENCODE_ATTACH=true
 
 Exit Codes:
     0    Success

--- a/codeagent-wrapper/opencode_isolation_unix.go
+++ b/codeagent-wrapper/opencode_isolation_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func isolateOpencodeExecCmd(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}

--- a/codeagent-wrapper/opencode_isolation_windows.go
+++ b/codeagent-wrapper/opencode_isolation_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func isolateOpencodeExecCmd(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= 0x00000200
+}

--- a/codeagent-wrapper/parser.go
+++ b/codeagent-wrapper/parser.go
@@ -90,6 +90,31 @@ type UnifiedEvent struct {
 	Content        string `json:"content,omitempty"`
 	Delta          *bool  `json:"delta,omitempty"`
 	Status         string `json:"status,omitempty"`
+
+	// Opencode-specific fields
+	Timestamp int64          `json:"timestamp,omitempty"`
+	Part      *OpencodePart  `json:"part,omitempty"`
+	Error     *OpencodeError `json:"error,omitempty"`
+}
+
+// OpencodePart represents the "part" field in opencode JSON events
+type OpencodePart struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	SessionID string          `json:"sessionID,omitempty"`
+	MessageID string          `json:"messageID,omitempty"`
+	Tool      string          `json:"tool,omitempty"`
+	CallID    string          `json:"callID,omitempty"`
+	Reason    string          `json:"reason,omitempty"`
+	State     json.RawMessage `json:"state,omitempty"`
+	Tokens    json.RawMessage `json:"tokens,omitempty"`
+}
+
+type OpencodeError struct {
+	Name string `json:"name,omitempty"`
+	Data struct {
+		Message string `json:"message,omitempty"`
+	} `json:"data,omitempty"`
 }
 
 // GetSessionID returns the session ID from either snake_case or camelCase field.
@@ -143,9 +168,10 @@ func parseJSONStreamInternalWithContent(r io.Reader, warnFn func(string), infoFn
 	totalEvents := 0
 
 	var (
-		codexMessage  string
-		claudeMessage string
-		geminiBuffer  strings.Builder
+		codexMessage   string
+		claudeMessage  string
+		geminiBuffer   strings.Builder
+		opencodeBuffer strings.Builder
 	)
 
 	for {
@@ -209,6 +235,7 @@ func parseJSONStreamInternalWithContent(r io.Reader, warnFn func(string), infoFn
 		}
 		isGemini := event.Role != "" || event.Delta != nil || event.Status != "" ||
 			(event.Type == "init" && event.GetSessionID() != "")
+		isOpencode := event.Part != nil || event.Timestamp > 0 || event.Error != nil
 
 		// Handle Codex events
 		if isCodex {
@@ -372,11 +399,85 @@ func parseJSONStreamInternalWithContent(r io.Reader, warnFn func(string), infoFn
 			continue
 		}
 
+		// Handle Opencode events
+		if isOpencode {
+			if event.Part != nil && event.Part.SessionID != "" && threadID == "" {
+				threadID = event.Part.SessionID
+				if onSessionStarted != nil {
+					onSessionStarted(threadID)
+				}
+			}
+
+			switch event.Type {
+			case "step_start":
+				emitProgress(formatProgressLine("turn_started", nil))
+				sid := ""
+				if event.Part != nil {
+					sid = event.Part.SessionID
+				}
+				infoFn(fmt.Sprintf("Parsed Opencode event #%d type=step_start sessionID=%s", totalEvents, sid))
+
+			case "text":
+				textLen := 0
+				if event.Part != nil && event.Part.Text != "" {
+					textLen = len(event.Part.Text)
+					opencodeBuffer.WriteString(event.Part.Text)
+					notifyMessage()
+					if onContent != nil {
+						onContent(event.Part.Text, "message")
+					}
+					emitProgress(formatProgressLine("message", map[string]string{"text": strconv.Quote(safeProgressSnippet(event.Part.Text, 120))}))
+				}
+				infoFn(fmt.Sprintf("Parsed Opencode event #%d type=text text_len=%d", totalEvents, textLen))
+
+			case "tool_use":
+				toolName := ""
+				if event.Part != nil {
+					toolName = event.Part.Tool
+				}
+				emitProgress(formatProgressLine("mcp_call", map[string]string{"cmd": strconv.Quote(toolName)}))
+				infoFn(fmt.Sprintf("Parsed Opencode event #%d type=tool_use tool=%s", totalEvents, toolName))
+
+			case "step_finish":
+				reason := ""
+				if event.Part != nil {
+					reason = event.Part.Reason
+				}
+				infoFn(fmt.Sprintf("Parsed Opencode event #%d type=step_finish reason=%s", totalEvents, reason))
+				emitProgress(formatProgressLine("turn_completed", nil))
+				notifyComplete()
+
+			case "error":
+				errMsg := ""
+				if event.Part != nil {
+					errMsg = event.Part.Text
+				}
+				if errMsg == "" && event.Error != nil {
+					errMsg = event.Error.Data.Message
+					if errMsg == "" {
+						errMsg = event.Error.Name
+					}
+				}
+				infoFn(fmt.Sprintf("Parsed Opencode event #%d type=error error=%s", totalEvents, errMsg))
+				emitProgress(formatProgressLine("error", map[string]string{"text": strconv.Quote(safeProgressSnippet(errMsg, 120))}))
+
+			default:
+				if event.Part != nil {
+					infoFn(fmt.Sprintf("Parsed Opencode event #%d type=%s part_type=%s", totalEvents, event.Type, event.Part.Type))
+				} else {
+					infoFn(fmt.Sprintf("Parsed Opencode event #%d type=%s", totalEvents, event.Type))
+				}
+			}
+			continue
+		}
+
 		// Unknown event format from other backends (turn.started/assistant/user); ignore.
 		continue
 	}
 
 	switch {
+	case opencodeBuffer.Len() > 0:
+		message = opencodeBuffer.String()
 	case geminiBuffer.Len() > 0:
 		message = geminiBuffer.String()
 	case claudeMessage != "":


### PR DESCRIPTION
## Summary
- add opencode as a selectable codeagent-wrapper backend
- support opencode model configuration, JSON event parsing, and prompt/workdir invocation
- isolate opencode child execution and default to standalone mode to avoid nested desktop-server attach failures