### PR TITLE
fix: align Codex agent templates with schema

### DIFF
--- a/templates/codex/agents/ccg-implement.toml
+++ b/templates/codex/agents/ccg-implement.toml
@@ -3,15 +3,9 @@
 
 name = "ccg-implement"
 description = "Implementation worker — writes code for assigned files following the plan"
+sandbox_mode = "workspace-write"
 
-[sandbox]
-mode = "workspace-write"
-
-[features]
-multi_agent = false  # Prevent recursion — workers don't spawn workers
-
-[developer_instructions]
-text = """
+developer_instructions = """
 You are a CCG implementation worker. You have been dispatched by the lead agent.
 
 ## Rules

--- a/templates/codex/agents/ccg-research.toml
+++ b/templates/codex/agents/ccg-research.toml
@@ -3,15 +3,9 @@
 
 name = "ccg-research"
 description = "Research worker — explores codebase, maps dependencies, gathers context"
+sandbox_mode = "read-only"
 
-[sandbox]
-mode = "read-only"  # Research never writes
-
-[features]
-multi_agent = false
-
-[developer_instructions]
-text = """
+developer_instructions = """
 You are a CCG research worker. You have been dispatched to gather information.
 
 ## Steps

--- a/templates/codex/agents/ccg-review.toml
+++ b/templates/codex/agents/ccg-review.toml
@@ -3,15 +3,9 @@
 
 name = "ccg-review"
 description = "Review worker — runs lint, typecheck, tests and reports findings"
+sandbox_mode = "workspace-write"
 
-[sandbox]
-mode = "workspace-write"  # Needs write to auto-fix lint issues
-
-[features]
-multi_agent = false
-
-[developer_instructions]
-text = """
+developer_instructions = """
 You are a CCG review worker. You have been dispatched to verify code quality.
 
 ## Steps


### PR DESCRIPTION
## Summary
- Use top-level \sandbox_mode\ in Codex agent templates
- Use top-level string \developer_instructions\ instead of a nested table
- Remove unsupported \eatures.multi_agent\ blocks from the agent templates

## Verification
- \pnpm typecheck\`n- Parsed all three Codex agent TOML templates with \smol-toml\ and verified \developer_instructions\ is a string

Note: \pnpm test\ currently fails on Windows in \installWorkflows.test.ts\ due to an existing CRLF assertion mismatch: expected \	ools: Read, Write\, received \	ools: Read, Write\\r\.