### PR TITLE
feat: add MiniMax backend provider

### DIFF
--- a/codeagent-wrapper/config.go
+++ b/codeagent-wrapper/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	MaxParallelWorkers int
 	GeminiModel        string // Gemini model name (empty = use default)
 	GrokModel          string // Grok model name (empty = use default)
+	MinimaxModel       string // MiniMax model name (empty = use default)
+	MinimaxRegion      string // MiniMax region key (empty = use default)
 	Progress           bool   // Emit compact progress lines to stderr
 }
 
@@ -33,18 +35,20 @@ type ParallelConfig struct {
 
 // TaskSpec describes an individual task entry in the parallel config
 type TaskSpec struct {
-	ID           string          `json:"id"`
-	Task         string          `json:"task"`
-	WorkDir      string          `json:"workdir,omitempty"`
-	Dependencies []string        `json:"dependencies,omitempty"`
-	SessionID    string          `json:"session_id,omitempty"`
-	Backend      string          `json:"backend,omitempty"`
-	Progress     bool            `json:"-"`
-	Mode         string          `json:"-"`
-	UseStdin     bool            `json:"-"`
-	GeminiModel  string          `json:"-"`
-	GrokModel    string          `json:"-"`
-	Context      context.Context `json:"-"`
+	ID            string          `json:"id"`
+	Task          string          `json:"task"`
+	WorkDir       string          `json:"workdir,omitempty"`
+	Dependencies  []string        `json:"dependencies,omitempty"`
+	SessionID     string          `json:"session_id,omitempty"`
+	Backend       string          `json:"backend,omitempty"`
+	Progress      bool            `json:"-"`
+	Mode          string          `json:"-"`
+	UseStdin      bool            `json:"-"`
+	GeminiModel   string          `json:"-"`
+	GrokModel     string          `json:"-"`
+	MinimaxModel  string          `json:"-"`
+	MinimaxRegion string          `json:"-"`
+	Context       context.Context `json:"-"`
 }
 
 // TaskResult captures the execution outcome of a task
@@ -73,6 +77,7 @@ var backendRegistry = map[string]Backend{
 	"antigravity": AntigravityBackend{},
 	"agy":         AntigravityBackend{},
 	"grok":        GrokBackend{},
+	"minimax":     MinimaxBackend{},
 }
 
 func selectBackend(name string) (Backend, error) {
@@ -209,6 +214,8 @@ func parseArgs() (*Config, error) {
 	// Read environment variables (lowest precedence)
 	geminiModel := strings.TrimSpace(os.Getenv("GEMINI_MODEL"))
 	grokModel := strings.TrimSpace(os.Getenv("GROK_MODEL"))
+	minimaxModel := strings.TrimSpace(os.Getenv("MINIMAX_MODEL"))
+	minimaxRegion := strings.TrimSpace(os.Getenv("MINIMAX_REGION"))
 
 	backendName := defaultBackendName
 	skipPermissions := envFlagEnabled("CODEAGENT_SKIP_PERMISSIONS")
@@ -270,6 +277,42 @@ func parseArgs() (*Config, error) {
 			}
 			grokModel = value
 			continue
+		case arg == "--minimax-model":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--minimax-model flag requires a non-empty model name")
+			}
+			value := strings.TrimSpace(args[i+1])
+			if value == "" {
+				return nil, fmt.Errorf("--minimax-model flag requires a non-empty model name")
+			}
+			minimaxModel = value
+			i++
+			continue
+		case strings.HasPrefix(arg, "--minimax-model="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--minimax-model="))
+			if value == "" {
+				return nil, fmt.Errorf("--minimax-model flag requires a non-empty model name")
+			}
+			minimaxModel = value
+			continue
+		case arg == "--minimax-region":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--minimax-region flag requires a non-empty region name")
+			}
+			value := strings.TrimSpace(args[i+1])
+			if value == "" {
+				return nil, fmt.Errorf("--minimax-region flag requires a non-empty region name")
+			}
+			minimaxRegion = value
+			i++
+			continue
+		case strings.HasPrefix(arg, "--minimax-region="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--minimax-region="))
+			if value == "" {
+				return nil, fmt.Errorf("--minimax-region flag requires a non-empty region name")
+			}
+			minimaxRegion = value
+			continue
 		case arg == "--skip-permissions", arg == "--dangerously-skip-permissions":
 			skipPermissions = true
 			continue
@@ -291,7 +334,7 @@ func parseArgs() (*Config, error) {
 	}
 	args = filtered
 
-	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel, GrokModel: grokModel, Progress: progress}
+	cfg := &Config{WorkDir: defaultWorkdir, Backend: backendName, SkipPermissions: skipPermissions, GeminiModel: geminiModel, GrokModel: grokModel, MinimaxModel: minimaxModel, MinimaxRegion: minimaxRegion, Progress: progress}
 	cfg.MaxParallelWorkers = resolveMaxParallelWorkers()
 
 	if args[0] == "resume" {

--- a/codeagent-wrapper/executor.go
+++ b/codeagent-wrapper/executor.go
@@ -821,14 +821,16 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 	logger := injectedLogger
 
 	cfg := &Config{
-		Mode:        taskSpec.Mode,
-		Task:        taskSpec.Task,
-		SessionID:   taskSpec.SessionID,
-		WorkDir:     taskSpec.WorkDir,
-		Backend:     defaultBackendName,
-		Progress:    taskSpec.Progress,
-		GeminiModel: taskSpec.GeminiModel,
-		GrokModel:   taskSpec.GrokModel,
+		Mode:          taskSpec.Mode,
+		Task:          taskSpec.Task,
+		SessionID:     taskSpec.SessionID,
+		WorkDir:       taskSpec.WorkDir,
+		Backend:       defaultBackendName,
+		Progress:      taskSpec.Progress,
+		GeminiModel:   taskSpec.GeminiModel,
+		GrokModel:     taskSpec.GrokModel,
+		MinimaxModel:  taskSpec.MinimaxModel,
+		MinimaxRegion: taskSpec.MinimaxRegion,
 	}
 
 	commandName := codexCommand
@@ -994,6 +996,9 @@ func runCodexTaskWithContext(parentCtx context.Context, taskSpec TaskSpec, backe
 	if env == nil {
 		env = make(map[string]string)
 	}
+	// Redirect the Claude CLI to MiniMax's regional Anthropic endpoint when the
+	// minimax backend is selected; no-op for every other backend.
+	applyMinimaxEnv(env, cfg)
 	cmd.SetEnv(env) // SetEnv 会自动合并 os.Environ() (executor.go:122-161)
 
 	// Set working directory for backends that don't support -C flag.

--- a/codeagent-wrapper/main.go
+++ b/codeagent-wrapper/main.go
@@ -228,7 +228,7 @@ func run() (exitCode int) {
 						return 1
 					}
 					backendName = value
-				case arg == "--gemini-model", arg == "--grok-model":
+				case arg == "--gemini-model", arg == "--grok-model", arg == "--minimax-model", arg == "--minimax-region":
 					// Bare form carries its value in the next arg — consume it too,
 					// otherwise the value lands in extras and hard-fails the run.
 					geminiModelInParallel = true
@@ -236,7 +236,7 @@ func run() (exitCode int) {
 						i++
 					}
 					continue
-				case strings.HasPrefix(arg, "--gemini-model="), strings.HasPrefix(arg, "--grok-model="):
+				case strings.HasPrefix(arg, "--gemini-model="), strings.HasPrefix(arg, "--grok-model="), strings.HasPrefix(arg, "--minimax-model="), strings.HasPrefix(arg, "--minimax-region="):
 					geminiModelInParallel = true
 					continue
 				default:
@@ -246,7 +246,7 @@ func run() (exitCode int) {
 
 			// Warn about unsupported parameter
 			if geminiModelInParallel {
-				logWarn("--gemini-model/--grok-model parameters are not supported in parallel mode")
+				logWarn("--gemini-model/--grok-model/--minimax-model/--minimax-region parameters are not supported in parallel mode")
 			}
 
 			if len(extras) > 0 {
@@ -394,6 +394,16 @@ func run() (exitCode int) {
 		logWarn("--grok-model parameter is only effective with --backend grok")
 	}
 
+	if cfg.MinimaxModel != "" && cfg.Backend == "minimax" {
+		logInfo(fmt.Sprintf("Using MiniMax model: %s", cfg.MinimaxModel))
+	}
+	if cfg.MinimaxModel != "" && cfg.Backend != "minimax" {
+		logWarn("--minimax-model parameter is only effective with --backend minimax")
+	}
+	if cfg.MinimaxRegion != "" && cfg.Backend != "minimax" {
+		logWarn("--minimax-region parameter is only effective with --backend minimax")
+	}
+
 	timeoutSec := resolveTimeout()
 	logInfo(fmt.Sprintf("Timeout: %ds", timeoutSec))
 	cfg.Timeout = timeoutSec
@@ -497,15 +507,17 @@ func run() (exitCode int) {
 	logInfo(fmt.Sprintf("%s running...", cfg.Backend))
 
 	taskSpec := TaskSpec{
-		Task:        taskText,
-		WorkDir:     cfg.WorkDir,
-		Mode:        cfg.Mode,
-		SessionID:   cfg.SessionID,
-		UseStdin:    useStdin,
-		Progress:    cfg.Progress,
-		Backend:     cfg.Backend,
-		GeminiModel: cfg.GeminiModel,
-		GrokModel:   cfg.GrokModel,
+		Task:          taskText,
+		WorkDir:       cfg.WorkDir,
+		Mode:          cfg.Mode,
+		SessionID:     cfg.SessionID,
+		UseStdin:      useStdin,
+		Progress:      cfg.Progress,
+		Backend:       cfg.Backend,
+		GeminiModel:   cfg.GeminiModel,
+		GrokModel:     cfg.GrokModel,
+		MinimaxModel:  cfg.MinimaxModel,
+		MinimaxRegion: cfg.MinimaxRegion,
 	}
 
 	result := runTaskFn(taskSpec, false, cfg.Timeout)

--- a/codeagent-wrapper/minimax.go
+++ b/codeagent-wrapper/minimax.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// MiniMax is integrated by driving the same Claude CLI binary against MiniMax's
+// Anthropic-compatible endpoint. This keeps the backend surface identical to
+// the other CLI backends: the model is pinned via --model in BuildArgs, while
+// the regional API base URL and API key are redirected through environment
+// variables in applyMinimaxEnv.
+
+const (
+	// defaultMinimaxModel is used when neither --minimax-model nor the
+	// MINIMAX_MODEL environment variable supplies a model name.
+	defaultMinimaxModel = "MiniMax-M3"
+
+	// defaultMinimaxRegion selects the global endpoint by default.
+	defaultMinimaxRegion = "global_en"
+)
+
+// minimaxEndpoint holds the regional API base URLs MiniMax exposes.
+type minimaxEndpoint struct {
+	OpenAIBaseURL    string
+	AnthropicBaseURL string
+}
+
+// minimaxEndpoints maps a region key to its base URLs. Both the global and the
+// mainland-China regions are supported; the Anthropic base URL is what drives
+// the Claude CLI, and the OpenAI base URL is kept alongside it for parity.
+var minimaxEndpoints = map[string]minimaxEndpoint{
+	"global_en": {
+		OpenAIBaseURL:    "https://api.minimax.io/v1",
+		AnthropicBaseURL: "https://api.minimax.io/anthropic",
+	},
+	"cn_zh": {
+		OpenAIBaseURL:    "https://api.minimaxi.com/v1",
+		AnthropicBaseURL: "https://api.minimaxi.com/anthropic",
+	},
+}
+
+// resolveMinimaxRegion normalises a region string, falling back to the default
+// region when it is empty or unknown.
+func resolveMinimaxRegion(region string) string {
+	key := strings.ToLower(strings.TrimSpace(region))
+	if key == "" {
+		return defaultMinimaxRegion
+	}
+	if _, ok := minimaxEndpoints[key]; ok {
+		return key
+	}
+	return defaultMinimaxRegion
+}
+
+// resolveMinimaxModel returns the configured model, or the default when empty.
+func resolveMinimaxModel(model string) string {
+	if m := strings.TrimSpace(model); m != "" {
+		return m
+	}
+	return defaultMinimaxModel
+}
+
+// MinimaxBackend runs the Claude CLI against MiniMax's Anthropic-compatible API.
+type MinimaxBackend struct{}
+
+func (MinimaxBackend) Name() string { return "minimax" }
+
+// Command reuses the claude CLI binary. MiniMax exposes an Anthropic-compatible
+// endpoint, so the same executable drives it once the base URL and auth token
+// are redirected via environment variables (see applyMinimaxEnv).
+func (MinimaxBackend) Command() string { return "claude" }
+
+func (MinimaxBackend) BuildArgs(cfg *Config, targetArg string) []string {
+	return buildMinimaxArgs(cfg, targetArg)
+}
+
+// buildMinimaxArgs mirrors buildClaudeArgs and pins the MiniMax model via
+// --model so each request targets the selected model.
+func buildMinimaxArgs(cfg *Config, targetArg string) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	// Same non-interactive flags as the claude backend: the wrapper only ever
+	// runs autonomous orchestration sub-tasks, and setting sources are disabled
+	// to avoid recursively triggering codeagent.
+	args := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", ""}
+
+	// Pin the MiniMax model (default MiniMax-M3, or any model from the flag/env).
+	args = append(args, "--model", resolveMinimaxModel(cfg.MinimaxModel))
+
+	if cfg.Mode == "resume" && cfg.SessionID != "" {
+		args = append(args, "-r", cfg.SessionID)
+	}
+
+	args = append(args, "--output-format", "stream-json", "--verbose", targetArg)
+
+	return args
+}
+
+// applyMinimaxEnv redirects the Claude CLI to MiniMax's regional Anthropic
+// endpoint and maps the MiniMax API key onto the variable the CLI reads. It is
+// a no-op for every other backend, so it is safe to call unconditionally.
+func applyMinimaxEnv(env map[string]string, cfg *Config) {
+	if env == nil || cfg == nil || cfg.Backend != "minimax" {
+		return
+	}
+
+	endpoint := minimaxEndpoints[resolveMinimaxRegion(cfg.MinimaxRegion)]
+	env["ANTHROPIC_BASE_URL"] = endpoint.AnthropicBaseURL
+
+	if key := strings.TrimSpace(os.Getenv("MINIMAX_API_KEY")); key != "" {
+		env["ANTHROPIC_AUTH_TOKEN"] = key
+	}
+}

--- a/codeagent-wrapper/minimax_test.go
+++ b/codeagent-wrapper/minimax_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+// withArgs runs fn with os.Args set to the given argv (program name prepended),
+// restoring the original os.Args afterwards.
+func withArgs(t *testing.T, argv []string, fn func()) {
+	t.Helper()
+	old := os.Args
+	t.Cleanup(func() { os.Args = old })
+	os.Args = append([]string{"codeagent-wrapper"}, argv...)
+	fn()
+}
+
+func TestMinimaxBackend_Metadata(t *testing.T) {
+	b := MinimaxBackend{}
+	if b.Name() != "minimax" {
+		t.Fatalf("Name() = %s, want minimax", b.Name())
+	}
+	// MiniMax exposes an Anthropic-compatible endpoint, so it drives the claude CLI.
+	if b.Command() != "claude" {
+		t.Fatalf("Command() = %s, want claude", b.Command())
+	}
+}
+
+func TestMinimaxBuildArgs_NewModeDefaultModel(t *testing.T) {
+	backend := MinimaxBackend{}
+	cfg := &Config{Mode: "new", WorkDir: "/repo", Backend: "minimax"}
+	got := backend.BuildArgs(cfg, "todo")
+	want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--model", "MiniMax-M3", "--output-format", "stream-json", "--verbose", "todo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestMinimaxBuildArgs_CustomModel(t *testing.T) {
+	backend := MinimaxBackend{}
+	cfg := &Config{Mode: "new", WorkDir: "/repo", Backend: "minimax", MinimaxModel: "MiniMax-M2.7"}
+	got := backend.BuildArgs(cfg, "todo")
+	want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--model", "MiniMax-M2.7", "--output-format", "stream-json", "--verbose", "todo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestMinimaxBuildArgs_ResumeMode(t *testing.T) {
+	backend := MinimaxBackend{}
+	cfg := &Config{Mode: "resume", SessionID: "sid-123", WorkDir: "/ignored", Backend: "minimax"}
+	got := backend.BuildArgs(cfg, "resume-task")
+	want := []string{"-p", "--dangerously-skip-permissions", "--setting-sources", "", "--model", "MiniMax-M3", "-r", "sid-123", "--output-format", "stream-json", "--verbose", "resume-task"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestMinimaxBuildArgs_NilConfig(t *testing.T) {
+	if args := (MinimaxBackend{}).BuildArgs(nil, "ignored"); args != nil {
+		t.Fatalf("nil config should return nil args, got %v", args)
+	}
+}
+
+func TestResolveMinimaxModel(t *testing.T) {
+	if got := resolveMinimaxModel(""); got != "MiniMax-M3" {
+		t.Fatalf("empty model = %s, want MiniMax-M3", got)
+	}
+	if got := resolveMinimaxModel("  "); got != "MiniMax-M3" {
+		t.Fatalf("blank model = %s, want MiniMax-M3", got)
+	}
+	if got := resolveMinimaxModel("MiniMax-M2.7"); got != "MiniMax-M2.7" {
+		t.Fatalf("custom model = %s, want MiniMax-M2.7", got)
+	}
+}
+
+func TestResolveMinimaxRegion(t *testing.T) {
+	cases := map[string]string{
+		"":          "global_en",
+		"  ":        "global_en",
+		"global_en": "global_en",
+		"GLOBAL_EN": "global_en",
+		"cn_zh":     "cn_zh",
+		"CN_ZH":     "cn_zh",
+		"unknown":   "global_en",
+	}
+	for in, want := range cases {
+		if got := resolveMinimaxRegion(in); got != want {
+			t.Fatalf("resolveMinimaxRegion(%q) = %s, want %s", in, got, want)
+		}
+	}
+}
+
+func TestMinimaxEndpoints_CoverBothRegions(t *testing.T) {
+	global, ok := minimaxEndpoints["global_en"]
+	if !ok {
+		t.Fatal("missing global_en endpoint")
+	}
+	if global.OpenAIBaseURL != "https://api.minimax.io/v1" || global.AnthropicBaseURL != "https://api.minimax.io/anthropic" {
+		t.Fatalf("global endpoint mismatch: %+v", global)
+	}
+
+	cn, ok := minimaxEndpoints["cn_zh"]
+	if !ok {
+		t.Fatal("missing cn_zh endpoint")
+	}
+	if cn.OpenAIBaseURL != "https://api.minimaxi.com/v1" || cn.AnthropicBaseURL != "https://api.minimaxi.com/anthropic" {
+		t.Fatalf("cn endpoint mismatch: %+v", cn)
+	}
+}
+
+func TestApplyMinimaxEnv_GlobalRegionDefault(t *testing.T) {
+	env := map[string]string{}
+	applyMinimaxEnv(env, &Config{Backend: "minimax"})
+	if env["ANTHROPIC_BASE_URL"] != "https://api.minimax.io/anthropic" {
+		t.Fatalf("base url = %s, want global anthropic endpoint", env["ANTHROPIC_BASE_URL"])
+	}
+}
+
+func TestApplyMinimaxEnv_CNRegion(t *testing.T) {
+	env := map[string]string{}
+	applyMinimaxEnv(env, &Config{Backend: "minimax", MinimaxRegion: "cn_zh"})
+	if env["ANTHROPIC_BASE_URL"] != "https://api.minimaxi.com/anthropic" {
+		t.Fatalf("base url = %s, want cn anthropic endpoint", env["ANTHROPIC_BASE_URL"])
+	}
+}
+
+func TestApplyMinimaxEnv_MapsAPIKey(t *testing.T) {
+	t.Setenv("MINIMAX_API_KEY", "test-key")
+	env := map[string]string{}
+	applyMinimaxEnv(env, &Config{Backend: "minimax"})
+	if env["ANTHROPIC_AUTH_TOKEN"] != "test-key" {
+		t.Fatalf("auth token = %q, want test-key", env["ANTHROPIC_AUTH_TOKEN"])
+	}
+}
+
+func TestApplyMinimaxEnv_NoopForOtherBackends(t *testing.T) {
+	env := map[string]string{}
+	applyMinimaxEnv(env, &Config{Backend: "claude"})
+	if _, ok := env["ANTHROPIC_BASE_URL"]; ok {
+		t.Fatalf("claude backend should not receive MiniMax base url: %v", env)
+	}
+}
+
+func TestSelectBackend_Minimax(t *testing.T) {
+	for _, name := range []string{"minimax", "MiniMax", "  MINIMAX  "} {
+		backend, err := selectBackend(name)
+		if err != nil {
+			t.Fatalf("selectBackend(%q) error: %v", name, err)
+		}
+		if _, ok := backend.(MinimaxBackend); !ok {
+			t.Fatalf("selectBackend(%q) = %T, want MinimaxBackend", name, backend)
+		}
+	}
+}
+
+func TestParseArgs_MinimaxModelAndRegion(t *testing.T) {
+	t.Run("flags", func(t *testing.T) {
+		withArgs(t, []string{"--backend", "minimax", "--minimax-model", "MiniMax-M2.7", "--minimax-region", "cn_zh", "task"}, func() {
+			cfg, err := parseArgs()
+			if err != nil {
+				t.Fatalf("parseArgs error: %v", err)
+			}
+			if cfg.MinimaxModel != "MiniMax-M2.7" {
+				t.Fatalf("model = %q, want MiniMax-M2.7", cfg.MinimaxModel)
+			}
+			if cfg.MinimaxRegion != "cn_zh" {
+				t.Fatalf("region = %q, want cn_zh", cfg.MinimaxRegion)
+			}
+		})
+	})
+
+	t.Run("env fallback", func(t *testing.T) {
+		t.Setenv("MINIMAX_MODEL", "MiniMax-M3")
+		t.Setenv("MINIMAX_REGION", "global_en")
+		withArgs(t, []string{"--backend", "minimax", "task"}, func() {
+			cfg, err := parseArgs()
+			if err != nil {
+				t.Fatalf("parseArgs error: %v", err)
+			}
+			if cfg.MinimaxModel != "MiniMax-M3" || cfg.MinimaxRegion != "global_en" {
+				t.Fatalf("env fallback failed: model=%q region=%q", cfg.MinimaxModel, cfg.MinimaxRegion)
+			}
+		})
+	})
+
+	t.Run("empty flag rejected", func(t *testing.T) {
+		withArgs(t, []string{"--minimax-model=", "task"}, func() {
+			if _, err := parseArgs(); err == nil {
+				t.Fatal("expected error for empty --minimax-model")
+			}
+		})
+	})
+}


### PR DESCRIPTION
Reason: The executable backend layer has no MiniMax inference backend, so MiniMax cannot be selected as an execution provider.

## Summary

Adds MiniMax as a selectable backend in `codeagent-wrapper`, following the same
`Backend` interface pattern used by the existing backends. MiniMax exposes an
Anthropic-compatible endpoint, so the backend drives the `claude` CLI and simply
redirects it to MiniMax's regional API base URL, keeping the integration small
and consistent with the existing backends.

## Changes

- **minimax.go** (new): `MinimaxBackend` implementing `Name()`, `Command()`, and
  `BuildArgs()`. It pins the model via `--model` (default `MiniMax-M3`, and
  `MiniMax-M2.7` selectable) and resolves the regional endpoint. Both regions are
  supported — `global_en` (`https://api.minimax.io`) and `cn_zh`
  (`https://api.minimaxi.com`) — each carrying its OpenAI- and Anthropic-compatible
  base URLs. `applyMinimaxEnv` redirects `ANTHROPIC_BASE_URL` per region and maps
  `MINIMAX_API_KEY` onto the token the CLI reads; it is a no-op for other backends.
- **config.go**: registers `minimax` in the backend registry, adds `MinimaxModel`
  and `MinimaxRegion` to `Config`/`TaskSpec`, and parses `--minimax-model` /
  `--minimax-region` flags plus the `MINIMAX_MODEL` / `MINIMAX_REGION` env vars.
- **main.go**: threads the model/region into the task spec, logs the selected
  MiniMax model, warns when the flags are used with another backend, and accepts
  the flags in parallel mode (mirroring the existing handling).
- **executor.go**: threads the fields into the rebuilt config and applies the
  MiniMax environment before launching the command.
- **minimax_test.go** (new): backend metadata, `BuildArgs` (default/custom model,
  resume, nil config), region and model resolution, both regional endpoints, env
  injection (global/CN/api-key/no-op), registry lookup, and flag/env parsing.

## Test Plan

- `go build ./...` — passes
- `go vet .` — passes
- `go test -run 'Minimax|MiniMax|SelectBackend_Minimax|ParseArgs_Minimax' .` — all new tests pass
- Full `go test .` has a set of pre-existing failures in this sandbox (they
  depend on external CLI binaries, writable temp dirs, and process timing);
  verified against the base branch that the same tests fail without this change,
  and this change adds no new deterministic failures.
